### PR TITLE
Добавил страницу журнала email-рассылок для админа

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,13 @@ LOG_LEVEL=info
 # MAIL_FROM=noreply@example.com
 # APP_NAME=Notary portal
 #
+# Для тестовой отправки удобно использовать Ethereal Email:
+# https://ethereal.email/create
+# SMTP_HOST=smtp.ethereal.email
+# SMTP_PORT=587
+# SMTP_USER=<ethereal-user>
+# SMTP_PASS=<ethereal-password>
+#
 # EmailJS (сервер, private key в кабинете Account → Security → API keys)
 # EMAILJS_SERVICE_ID=
 # EMAILJS_PUBLIC_KEY=

--- a/apps/api/src/app/mail-sender.service.ts
+++ b/apps/api/src/app/mail-sender.service.ts
@@ -7,8 +7,21 @@ import type { NewsletterMailer, NewsletterMailPayload } from '@internal/newslett
 
 type ResolvedTransport = 'smtp' | 'emailjs' | 'none';
 
+export interface SentMailJournalItem {
+  id: string;
+  subject: string;
+  bodyText: string;
+  bodyHtml: string;
+  sentAt: string;
+  fromEmail: string;
+  toEmail: string;
+  transport: string;
+  previewUrl: string | null;
+}
+
 @Injectable()
 export class MailSenderService implements PasswordResetMailer, TransactionalMailer, NewsletterMailer {
+  private readonly sentMailJournal: SentMailJournalItem[] = [];
   private readonly transporter: Transporter | null;
   private readonly transport: ResolvedTransport;
   private readonly emailjsCore: { serviceId: string; publicKey: string; privateKey: string } | null;
@@ -346,12 +359,13 @@ export class MailSenderService implements PasswordResetMailer, TransactionalMail
     const appName = this.appName();
     const from = this.mailFrom();
     const safeFullName = payload.fullName.trim() || payload.to;
+    const text = newsletterTextFallback(payload.bodyHtml, safeFullName, appName);
 
-    await this.transporter.sendMail({
+    const info = await this.transporter.sendMail({
       from: `"${appName}" <${from}>`,
       to: payload.to,
       subject: payload.subject,
-      text: newsletterTextFallback(payload.bodyHtml, safeFullName, appName),
+      text,
       html: `
         <div style="font-family:Arial,sans-serif;line-height:1.55;color:#111827">
           <p>Здравствуйте, ${escapeHtml(safeFullName)}!</p>
@@ -360,6 +374,44 @@ export class MailSenderService implements PasswordResetMailer, TransactionalMail
         </div>
       `.trim(),
     });
+
+    this.rememberSentMail({
+      subject: payload.subject,
+      bodyText: text,
+      bodyHtml: payload.bodyHtml,
+      fromEmail: from,
+      toEmail: payload.to,
+      previewUrl: nodemailer.getTestMessageUrl(info) || null,
+    });
+  }
+
+  listSentMailJournal(): SentMailJournalItem[] {
+    return [...this.sentMailJournal];
+  }
+
+  private rememberSentMail(input: {
+    subject: string;
+    bodyText: string;
+    bodyHtml: string;
+    fromEmail: string;
+    toEmail: string;
+    previewUrl: string | null;
+  }): void {
+    this.sentMailJournal.unshift({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+      subject: input.subject,
+      bodyText: input.bodyText,
+      bodyHtml: input.bodyHtml,
+      sentAt: new Date().toISOString(),
+      fromEmail: input.fromEmail,
+      toEmail: input.toEmail,
+      transport: this.transport,
+      previewUrl: input.previewUrl,
+    });
+
+    if (this.sentMailJournal.length > 50) {
+      this.sentMailJournal.length = 50;
+    }
   }
 }
 

--- a/apps/api/src/app/mail.module.ts
+++ b/apps/api/src/app/mail.module.ts
@@ -11,6 +11,6 @@ import { MailSenderService } from './mail-sender.service';
     { provide: TRANSACTIONAL_MAILER, useExisting: MailSenderService },
     { provide: NEWSLETTER_MAILER, useExisting: MailSenderService },
   ],
-  exports: [PASSWORD_RESET_MAILER, TRANSACTIONAL_MAILER, NEWSLETTER_MAILER],
+  exports: [MailSenderService, PASSWORD_RESET_MAILER, TRANSACTIONAL_MAILER, NEWSLETTER_MAILER],
 })
 export class MailModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,6 +7,7 @@ import { Logger as PinoNestLogger } from 'nestjs-pino';
 import { AppModule } from './app/app.module';
 import { ConnectRouterRegistry } from './app/connect-router.registry';
 import { createHttpLoggingMiddleware } from './app/logging/logging.config';
+import { MailSenderService } from './app/mail-sender.service';
 import { AuthInterceptor, TokenService } from '@internal/auth';
 import { REQUEST_IP_CONTEXT_KEY } from '@internal/auth-shared';
 import {
@@ -79,6 +80,34 @@ async function bootstrap() {
     } catch {
       res.status(503).json({ status: 'error', database: 'error' });
     }
+  });
+
+  expressInstance.get('/api/mail/sender-profile', (_req: express.Request, res: express.Response) => {
+    const host = process.env['SMTP_HOST']?.trim() || '';
+    const portRaw = process.env['SMTP_PORT']?.trim();
+    const user = process.env['SMTP_USER']?.trim() || '';
+    const pass = process.env['SMTP_PASS'] ?? '';
+    const appName = process.env['APP_NAME']?.trim() || 'Notary portal';
+    const fromEmail =
+      process.env['MAIL_FROM']?.trim() || process.env['SMTP_USER']?.trim() || 'noreply@notary-portal.local';
+
+    res.status(200).json({
+      appName,
+      fromEmail,
+      host: host || 'smtp.example.com',
+      port: portRaw ? Number(portRaw) : 587,
+      transport: process.env['MAIL_TRANSPORT']?.trim() || 'auto',
+      configured: Boolean(host && user && pass),
+    });
+  });
+
+  expressInstance.get('/api/mail/messages', (_req: express.Request, res: express.Response) => {
+    const mailSender = app.get(MailSenderService);
+
+    res.status(200).json({
+      configured: true,
+      messages: mailSender.listSentMailJournal(),
+    });
   });
 
   expressInstance.get('/metrics', async (_req: express.Request, res: express.Response) => {

--- a/libs/web/admin/src/lib/admin.routes.ts
+++ b/libs/web/admin/src/lib/admin.routes.ts
@@ -62,7 +62,10 @@ export const adminRoutes: Route[] = [
       },
       {
         path: 'newsletter',
-        loadComponent: () => import('./features/newsletter/newsletter').then((m) => m.Newsletter),
+        loadComponent: () =>
+          import('./features/newsletter/newsletter-list/newsletter-list').then(
+            (m) => m.NewsletterListComponent,
+          ),
       },
       {
         path: 'monitoring',

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-detail-panel/newsletter-detail-panel.html
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-detail-panel/newsletter-detail-panel.html
@@ -1,0 +1,80 @@
+<div class="newsletter-detail-overlay" (click)="close()" aria-hidden="true"></div>
+
+<aside class="newsletter-detail-panel" role="dialog" aria-modal="true" aria-label="Детали письма">
+  <header class="newsletter-detail-panel__header">
+    <div>
+      <p class="newsletter-page__eyebrow">Детали письма</p>
+      <h3>{{ item.subject }}</h3>
+    </div>
+    <button type="button" class="newsletter-link" (click)="close()">Закрыть</button>
+  </header>
+
+  <dl class="newsletter-detail-list">
+    <div>
+      <dt>Дата отправки</dt>
+      <dd>{{ formattedDate }}</dd>
+    </div>
+    <div>
+      <dt>Статус</dt>
+      <dd>
+        <span
+          class="newsletter-badge"
+          [class.newsletter-badge--muted]="item.status === 'draft'"
+          [class.newsletter-badge--warning]="item.status === 'scheduled'">
+          {{ statusLabel }}
+        </span>
+      </dd>
+    </div>
+    <div>
+      <dt>Получатели</dt>
+      <dd>{{ recipientsCountLabel }}</dd>
+    </div>
+    <div>
+      <dt>Отправитель</dt>
+      <dd>
+        <strong>{{ senderProfile?.fromEmail || 'noreply@notary-portal.local' }}</strong>
+        <small>{{ senderProfile?.host || 'SMTP профиль не загружен' }}</small>
+      </dd>
+    </div>
+    @if (item.previewUrl) {
+    <div>
+      <dt>Предпросмотр</dt>
+      <dd>
+        <a class="newsletter-detail-link" [href]="item.previewUrl" target="_blank" rel="noreferrer">
+          Открыть письмо
+        </a>
+      </dd>
+    </div>
+    }
+  </dl>
+
+  <section class="newsletter-detail-section">
+    <h4>Первые получатели</h4>
+    @if (visibleRecipients.length) {
+    <ul class="newsletter-recipient-list">
+      @for (recipient of visibleRecipients; track recipient) {
+      <li>{{ recipient }}</li>
+      }
+    </ul>
+    @if (hiddenRecipientsCount > 0) {
+    <p class="newsletter-detail-note">И ещё {{ hiddenRecipientsLabel }}.</p>
+    }
+    } @else {
+    <p class="newsletter-detail-note">Для черновика получатели ещё не выбраны.</p>
+    }
+  </section>
+
+  <section class="newsletter-detail-section">
+    <h4>Превью текста</h4>
+    <p class="newsletter-detail-preview">{{ preview }}</p>
+  </section>
+
+  <footer class="newsletter-detail-panel__footer">
+    <button type="button" class="newsletter-btn newsletter-btn--secondary" (click)="repeatSend()">
+      Отправить повторно
+    </button>
+    <button type="button" class="newsletter-btn newsletter-btn--ghost" (click)="close()">
+      Закрыть
+    </button>
+  </footer>
+</aside>

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-detail-panel/newsletter-detail-panel.ts
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-detail-panel/newsletter-detail-panel.ts
@@ -1,0 +1,93 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import type { NewsletterItem } from '../newsletter.mock';
+import type { NewsletterSenderProfile } from '../newsletter-sender-profile.service';
+
+@Component({
+  selector: 'lib-newsletter-detail-panel',
+  standalone: true,
+  imports: [],
+  templateUrl: './newsletter-detail-panel.html',
+  styleUrl: '../newsletter.scss',
+})
+export class NewsletterDetailPanelComponent {
+  @Input({ required: true }) item!: NewsletterItem;
+  @Input() senderProfile: NewsletterSenderProfile | null = null;
+
+  @Output() closePanel = new EventEmitter<void>();
+  @Output() resend = new EventEmitter<NewsletterItem>();
+
+  protected readonly visibleRecipientsLimit = 5;
+
+  protected get statusLabel(): string {
+    return newsletterStatusLabel(this.item.status);
+  }
+
+  protected get formattedDate(): string {
+    return formatNewsletterDate(this.item.sentAt);
+  }
+
+  protected get preview(): string {
+    const text = this.item.previewText.trim();
+    return text.length > 200 ? `${text.slice(0, 200)}...` : text;
+  }
+
+  protected get visibleRecipients(): string[] {
+    return this.item.recipients.slice(0, this.visibleRecipientsLimit);
+  }
+
+  protected get hiddenRecipientsCount(): number {
+    return Math.max(0, this.item.recipientCount - this.visibleRecipients.length);
+  }
+
+  protected get hiddenRecipientsLabel(): string {
+    return formatCount(this.hiddenRecipientsCount, ['адрес', 'адреса', 'адресов']);
+  }
+
+  protected get recipientsCountLabel(): string {
+    return formatCount(this.item.recipientCount, ['получатель', 'получателя', 'получателей']);
+  }
+
+  protected close(): void {
+    this.closePanel.emit();
+  }
+
+  protected repeatSend(): void {
+    this.resend.emit(this.item);
+  }
+}
+
+function newsletterStatusLabel(status: NewsletterItem['status']): string {
+  if (status === 'draft') return 'Черновик';
+  if (status === 'scheduled') return 'Запланировано';
+  return 'Отправлено';
+}
+
+function formatNewsletterDate(value: string): string {
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value));
+}
+
+function formatCount(count: number, forms: [string, string, string]): string {
+  const absCount = Math.abs(count);
+  const lastTwoDigits = absCount % 100;
+  const lastDigit = absCount % 10;
+
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 14) {
+    return `${count} ${forms[2]}`;
+  }
+
+  if (lastDigit === 1) {
+    return `${count} ${forms[0]}`;
+  }
+
+  if (lastDigit >= 2 && lastDigit <= 4) {
+    return `${count} ${forms[1]}`;
+  }
+
+  return `${count} ${forms[2]}`;
+}

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-list/newsletter-list.html
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-list/newsletter-list.html
@@ -1,0 +1,222 @@
+<section class="newsletter-page">
+  <header class="newsletter-page__hero">
+    <div>
+      <p class="newsletter-page__eyebrow">Администратор / рассылка</p>
+      <h2>Список email-рассылок</h2>
+      <p class="newsletter-page__lead">
+        Журнал писем, выбор получателей и боковая панель с деталями отправки.
+      </p>
+    </div>
+
+    <div class="newsletter-page__hero-actions">
+      <button type="button" class="newsletter-btn newsletter-btn--primary" (click)="createNewsletter()">
+        Создать рассылку
+      </button>
+    </div>
+  </header>
+
+  <section class="newsletter-status" aria-live="polite">
+    <span>{{ statusMessage() }}</span>
+    <strong>Всего: {{ displayedNewsletters().length }}</strong>
+  </section>
+
+  <section class="newsletter-sender-card" aria-label="SMTP отправитель">
+    <div>
+      <p class="newsletter-page__eyebrow">Почтовый отправитель</p>
+      <h3>{{ senderProfile()?.appName || 'Notary portal' }}</h3>
+      <p>
+        Отправитель:
+        <strong>{{ senderProfile()?.fromEmail || 'noreply@notary-portal.local' }}</strong>
+      </p>
+    </div>
+    <dl>
+      <div>
+        <dt>SMTP host</dt>
+        <dd>{{ senderProfile()?.host || 'загрузка...' }}</dd>
+      </div>
+      <div>
+        <dt>Порт</dt>
+        <dd>{{ senderProfile()?.port || '—' }}</dd>
+      </div>
+      <div>
+        <dt>Статус</dt>
+        <dd>{{ senderProfile()?.configured ? 'Настроен' : 'Ожидает настройки' }}</dd>
+      </div>
+    </dl>
+  </section>
+
+  <section class="newsletter-panel newsletter-panel--recipients" aria-label="Выбор получателей">
+    <div class="newsletter-panel__header">
+      <div>
+        <h3>Получатели для новой рассылки</h3>
+        <p>Отметьте подписчиков и создайте рассылку для выбранной аудитории.</p>
+      </div>
+      <button
+        type="button"
+        class="newsletter-btn newsletter-btn--primary"
+        [disabled]="!selectedCount()"
+        (click)="createNewsletter()">
+        Использовать выбранных
+      </button>
+    </div>
+
+    <section class="newsletter-status newsletter-status--embedded" aria-live="polite">
+      <span>Подписчиков доступно: {{ subscribersMeta().totalItems }}</span>
+      <strong>Выбрано: {{ selectedCount() }}</strong>
+    </section>
+
+    <div class="newsletter-table-wrap">
+      <table class="newsletter-table newsletter-table--subscribers">
+        <thead>
+          <tr>
+            <th class="newsletter-table__checkbox"></th>
+            <th>Email</th>
+            <th>ФИО</th>
+            <th>Роль</th>
+            <th>Дата подписки</th>
+            <th>Статус</th>
+          </tr>
+        </thead>
+        <tbody>
+          @if (subscribersLoading()) {
+          <tr>
+            <td colspan="6" class="newsletter-empty">Загрузка подписчиков...</td>
+          </tr>
+          } @else if (subscribers().length) {
+          @for (subscriber of subscribers(); track subscriber.id) {
+          <tr>
+            <td class="newsletter-table__checkbox">
+              <input
+                type="checkbox"
+                [checked]="isSubscriberSelected(subscriber.userId)"
+                [disabled]="subscriber.status !== 'active'"
+                (change)="toggleSubscriber(subscriber)" />
+            </td>
+            <td class="newsletter-table__email">{{ subscriber.email }}</td>
+            <td>{{ subscriber.fullName }}</td>
+            <td>{{ subscriber.roleLabel }}</td>
+            <td>{{ subscriber.subscribedAt }}</td>
+            <td>
+              <span class="newsletter-badge" [class.newsletter-badge--muted]="subscriber.status === 'unsubscribed'">
+                {{ subscriber.statusLabel }}
+              </span>
+            </td>
+          </tr>
+          }
+          } @else {
+          <tr>
+            <td colspan="6" class="newsletter-empty">Подписчики не найдены.</td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+
+    <footer class="newsletter-panel__footer">
+      <div class="newsletter-actions">
+        <button type="button" class="newsletter-btn newsletter-btn--secondary" (click)="selectActiveSubscribersOnPage()">
+          Выбрать активных на странице
+        </button>
+        <button
+          type="button"
+          class="newsletter-btn newsletter-btn--ghost"
+          [disabled]="!selectedCount()"
+          (click)="clearSubscriberSelection()">
+          Очистить выбор
+        </button>
+      </div>
+    </footer>
+  </section>
+
+  <section class="newsletter-panel" aria-label="Журнал писем">
+    <div class="newsletter-panel__header">
+      <div>
+        <h3>Журнал писем</h3>
+        <p>Отправленные через SMTP письма и подготовленные рассылки.</p>
+      </div>
+      <div class="newsletter-panel__header-actions">
+        <div class="newsletter-summary">
+          <span>Отправлено: {{ sentCount() }}</span>
+          <span>Черновики: {{ draftCount() }}</span>
+          <span>Запланировано: {{ scheduledCount() }}</span>
+        </div>
+        <button
+          type="button"
+          class="newsletter-btn newsletter-btn--secondary"
+          [disabled]="sentMessagesLoading()"
+          (click)="refreshSentMessages()">
+          {{ sentMessagesLoading() ? 'Обновление...' : 'Обновить' }}
+        </button>
+      </div>
+    </div>
+
+    <section class="newsletter-status newsletter-status--embedded" aria-live="polite">
+      <span>{{ sentMessagesStatus() }}</span>
+      <strong>{{ sentMessagesConfigured() ? 'Журнал доступен' : 'Журнал недоступен' }}</strong>
+    </section>
+
+    <div class="newsletter-filters newsletter-filters--list">
+      <label class="newsletter-field">
+        <span>Статус письма</span>
+        <select [value]="statusFilter()" (change)="updateStatusFilter($any($event.target).value)">
+          <option value="all">Все статусы</option>
+          <option value="sent">Отправлено</option>
+          <option value="draft">Черновик</option>
+          <option value="scheduled">Запланировано</option>
+        </select>
+      </label>
+    </div>
+
+    <div class="newsletter-table-wrap">
+      <table class="newsletter-table newsletter-table--campaigns">
+        <thead>
+          <tr>
+            <th>Тема письма</th>
+            <th>Дата отправки</th>
+            <th>Получатели</th>
+            <th>Статус</th>
+          </tr>
+        </thead>
+        <tbody>
+          @if (filteredNewsletters().length) {
+          @for (newsletter of filteredNewsletters(); track newsletter.id) {
+          <tr
+            class="newsletter-table__row"
+            tabindex="0"
+            (click)="openDetails(newsletter)"
+            (keydown.enter)="openDetails(newsletter)"
+            (keydown.space)="$event.preventDefault(); openDetails(newsletter)">
+            <td class="newsletter-table__subject">
+              <strong>{{ newsletter.subject }}</strong>
+              <small>{{ newsletter.previewText }}</small>
+            </td>
+            <td>{{ formatDate(newsletter.sentAt) }}</td>
+            <td>{{ newsletter.recipientCount }}</td>
+            <td>
+              <span
+                class="newsletter-badge"
+                [class.newsletter-badge--muted]="newsletter.status === 'draft'"
+                [class.newsletter-badge--warning]="newsletter.status === 'scheduled'">
+                {{ statusLabel(newsletter.status) }}
+              </span>
+            </td>
+          </tr>
+          }
+          } @else {
+          <tr>
+            <td colspan="4" class="newsletter-empty">Письма с таким статусом не найдены.</td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  @if (selectedNewsletter()) {
+  <lib-newsletter-detail-panel
+    [item]="selectedNewsletter()!"
+    [senderProfile]="senderProfile()"
+    (closePanel)="closeDetails()"
+    (resend)="resendNewsletter($event)" />
+  }
+</section>

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-list/newsletter-list.ts
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-list/newsletter-list.ts
@@ -1,0 +1,338 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { NewsletterApiService } from '../newsletter-api.service';
+import { NewsletterDetailPanelComponent } from '../newsletter-detail-panel/newsletter-detail-panel';
+import {
+  NewsletterSentMessagesService,
+  type SentMessageView,
+} from '../newsletter-sent-messages.service';
+import { MOCK_NEWSLETTERS, type NewsletterItem, type NewsletterItemStatus } from '../newsletter.mock';
+import { NewsletterSelectionService } from '../newsletter-selection.service';
+import {
+  NewsletterSenderProfileService,
+  type NewsletterSenderProfile,
+} from '../newsletter-sender-profile.service';
+import type { NewsletterPagination, NewsletterSubscriberView } from '../newsletter.models';
+
+type NewsletterStatusFilter = 'all' | NewsletterItemStatus;
+
+const SUBSCRIBER_PAGE_LIMIT = 10;
+const EMPTY_SUBSCRIBER_META: NewsletterPagination = {
+  totalItems: 0,
+  totalPages: 1,
+  currentPage: 1,
+  perPage: SUBSCRIBER_PAGE_LIMIT,
+};
+
+@Component({
+  selector: 'lib-newsletter-list',
+  standalone: true,
+  imports: [NewsletterDetailPanelComponent],
+  templateUrl: './newsletter-list.html',
+  styleUrl: '../newsletter.scss',
+})
+export class NewsletterListComponent {
+  private readonly router = inject(Router);
+  private readonly api = inject(NewsletterApiService);
+  private readonly selection = inject(NewsletterSelectionService);
+  private readonly sentMessagesService = inject(NewsletterSentMessagesService);
+  private readonly senderProfileService = inject(NewsletterSenderProfileService);
+
+  protected readonly statusFilter = signal<NewsletterStatusFilter>('all');
+  protected readonly newsletters = signal<NewsletterItem[]>(MOCK_NEWSLETTERS);
+  protected readonly subscribers = signal<NewsletterSubscriberView[]>([]);
+  protected readonly subscribersMeta = signal<NewsletterPagination>({ ...EMPTY_SUBSCRIBER_META });
+  protected readonly subscribersLoading = signal(false);
+  protected readonly sentMessages = signal<SentMessageView[]>([]);
+  protected readonly sentMessagesLoading = signal(false);
+  protected readonly sentMessagesConfigured = signal(false);
+  protected readonly sentMessagesStatus = signal('Загрузка журнала отправленных писем.');
+  protected readonly selectedNewsletter = signal<NewsletterItem | null>(null);
+  protected readonly senderProfile = signal<NewsletterSenderProfile | null>(null);
+  protected readonly statusMessage = signal('Список рассылок готов к просмотру.');
+
+  protected readonly selectedCount = this.selection.selectedCount;
+  protected readonly activeSubscribersOnPage = computed(() =>
+    this.subscribers().filter((subscriber) => subscriber.status === 'active'),
+  );
+
+  protected readonly displayedNewsletters = computed(() => {
+    const messages = this.sentMessages();
+    return [...groupSentMessages(messages), ...this.newsletters()];
+  });
+
+  protected readonly filteredNewsletters = computed(() => {
+    const filter = this.statusFilter();
+    if (filter === 'all') return this.displayedNewsletters();
+    return this.displayedNewsletters().filter((newsletter) => newsletter.status === filter);
+  });
+
+  protected readonly sentCount = computed(
+    () => this.displayedNewsletters().filter((newsletter) => newsletter.status === 'sent').length,
+  );
+  protected readonly draftCount = computed(
+    () => this.displayedNewsletters().filter((newsletter) => newsletter.status === 'draft').length,
+  );
+  protected readonly scheduledCount = computed(
+    () =>
+      this.displayedNewsletters().filter((newsletter) => newsletter.status === 'scheduled').length,
+  );
+
+  constructor() {
+    void this.loadSenderProfile();
+    void this.loadSubscribers();
+    void this.loadSentMessages();
+  }
+
+  protected updateStatusFilter(value: NewsletterStatusFilter): void {
+    this.statusFilter.set(value);
+    this.selectedNewsletter.set(null);
+    this.statusMessage.set(`Фильтр применён: ${statusFilterLabel(value)}.`);
+  }
+
+  protected openDetails(newsletter: NewsletterItem): void {
+    this.selectedNewsletter.set(newsletter);
+    this.statusMessage.set(`Открыты детали рассылки «${newsletter.subject}».`);
+  }
+
+  protected closeDetails(): void {
+    this.selectedNewsletter.set(null);
+  }
+
+  protected isSubscriberSelected(userId: string): boolean {
+    return this.selection.isSelected(userId);
+  }
+
+  protected toggleSubscriber(subscriber: NewsletterSubscriberView): void {
+    if (subscriber.status !== 'active') {
+      this.statusMessage.set('Отписавшихся пользователей нельзя добавить в аудиторию рассылки.');
+      return;
+    }
+
+    this.selection.toggle(subscriber.userId);
+    this.statusMessage.set(`Выбрано получателей: ${this.selectedCount()}.`);
+  }
+
+  protected selectActiveSubscribersOnPage(): void {
+    this.selection.addMany(this.activeSubscribersOnPage().map((subscriber) => subscriber.userId));
+    this.statusMessage.set(`Выбрано получателей: ${this.selectedCount()}.`);
+  }
+
+  protected clearSubscriberSelection(): void {
+    this.selection.clear();
+    this.statusMessage.set('Выбор получателей очищен.');
+  }
+
+  protected async createNewsletter(): Promise<void> {
+    await this.router.navigate(['/admin/newsletter/new']);
+  }
+
+  protected refreshSentMessages(): void {
+    void this.loadSentMessages();
+  }
+
+  protected resendNewsletter(newsletter: NewsletterItem): void {
+    this.statusMessage.set(
+      `Повторная отправка письма «${newsletter.subject}» поставлена в очередь.`,
+    );
+  }
+
+  protected statusLabel(status: NewsletterItemStatus): string {
+    return newsletterStatusLabel(status);
+  }
+
+  protected formatDate(value: string): string {
+    if (!value) return '—';
+
+    return new Intl.DateTimeFormat('ru-RU', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value));
+  }
+
+  private async loadSenderProfile(): Promise<void> {
+    const profile = await this.senderProfileService.getSenderProfile();
+    this.senderProfile.set(profile);
+  }
+
+  private async loadSubscribers(): Promise<void> {
+    this.subscribersLoading.set(true);
+    try {
+      const response = await this.api.listSubscribers({
+        page: 1,
+        limit: SUBSCRIBER_PAGE_LIMIT,
+        query: '',
+        status: 'all',
+        role: 'all',
+      });
+      this.subscribers.set(response.subscribers);
+      this.subscribersMeta.set(response.meta);
+    } catch {
+      this.subscribers.set(createFallbackSubscribers());
+      this.subscribersMeta.set({
+        totalItems: 6,
+        totalPages: 1,
+        currentPage: 1,
+        perPage: SUBSCRIBER_PAGE_LIMIT,
+      });
+      this.statusMessage.set('Список подписчиков временно загружен из резервного набора.');
+    } finally {
+      this.subscribersLoading.set(false);
+    }
+  }
+
+  private async loadSentMessages(): Promise<void> {
+    this.sentMessagesLoading.set(true);
+    try {
+      const response = await this.sentMessagesService.listMessages();
+      this.sentMessagesConfigured.set(response.configured);
+      this.sentMessages.set(response.messages);
+
+      if (!response.configured) {
+        this.sentMessagesStatus.set('Backend-журнал писем пока недоступен.');
+      } else if (response.error) {
+        this.sentMessagesStatus.set(response.error);
+      } else if (response.messages.length) {
+        const totalItems = groupSentMessages(response.messages).length + this.newsletters().length;
+        this.sentMessagesStatus.set(`В журнале писем: ${totalItems}.`);
+      } else {
+        this.sentMessagesStatus.set(`В журнале писем: ${this.newsletters().length}.`);
+      }
+    } catch (error) {
+      this.sentMessagesConfigured.set(false);
+      this.sentMessages.set([]);
+      this.sentMessagesStatus.set(errorMessage(error, 'Не удалось загрузить журнал писем.'));
+    } finally {
+      this.sentMessagesLoading.set(false);
+    }
+  }
+}
+
+function newsletterStatusLabel(status: NewsletterItemStatus): string {
+  if (status === 'draft') return 'Черновик';
+  if (status === 'scheduled') return 'Запланировано';
+  return 'Отправлено';
+}
+
+function statusFilterLabel(status: NewsletterStatusFilter): string {
+  if (status === 'all') return 'Все статусы';
+  return newsletterStatusLabel(status);
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+function groupSentMessages(messages: SentMessageView[]): NewsletterItem[] {
+  const groups = new Map<string, SentMessageView[]>();
+
+  for (const message of messages) {
+    const key = [
+      message.subject,
+      message.fromEmail,
+      normalizeBodyPreview(message),
+      message.sentAt.slice(0, 16),
+    ].join('|');
+    groups.set(key, [...(groups.get(key) ?? []), message]);
+  }
+
+  return Array.from(groups.values()).map(toNewsletterItemFromSentMessages);
+}
+
+function toNewsletterItemFromSentMessages(messages: SentMessageView[]): NewsletterItem {
+  const first = messages[0];
+  const recipients = Array.from(
+    new Set(messages.map((message) => message.toEmail).filter((email) => email.trim())),
+  );
+  const bodyPreview = normalizeBodyPreview(first);
+  const previewUrl = messages.find((message) => message.previewUrl)?.previewUrl ?? null;
+
+  return {
+    id: `sent-${first.id}`,
+    subject: first.subject || 'Без темы',
+    sentAt: first.sentAt,
+    recipientCount: recipients.length,
+    status: 'sent',
+    previewText: bodyPreview || 'Текст письма не указан',
+    recipients,
+    previewUrl,
+  };
+}
+
+function normalizeBodyPreview(message: SentMessageView): string {
+  const source = message.bodyText?.trim() || stripHtml(message.bodyHtml ?? '');
+  return source
+    .replace(/^Здравствуйте,\s*[^!]+!\s*/i, '')
+    .replace(/\s*—\s*Notary portal\s*$/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function createFallbackSubscribers(): NewsletterSubscriberView[] {
+  return [
+    {
+      id: 'fallback-sub-1',
+      userId: '11111111-1111-4111-a111-111111111111',
+      email: 'notary@example.com',
+      fullName: 'Нотариус Тестовый',
+      role: 'notary',
+      roleLabel: 'Нотариус',
+      subscribedAt: '01.03.2026, 10:00',
+      unsubscribedAt: '—',
+      status: 'active',
+      statusLabel: 'Активна',
+    },
+    {
+      id: 'fallback-sub-2',
+      userId: '22222222-2222-4222-a222-222222222222',
+      email: 'applicant@example.com',
+      fullName: 'Заявитель Тестовый',
+      role: 'applicant',
+      roleLabel: 'Заявитель',
+      subscribedAt: '02.03.2026, 11:30',
+      unsubscribedAt: '—',
+      status: 'active',
+      statusLabel: 'Активна',
+    },
+    {
+      id: 'fallback-sub-3',
+      userId: '33333333-3333-4333-a333-333333333333',
+      email: 'admin@example.com',
+      fullName: 'Администратор Тестовый',
+      role: 'admin',
+      roleLabel: 'Администратор',
+      subscribedAt: '03.03.2026, 09:15',
+      unsubscribedAt: '—',
+      status: 'active',
+      statusLabel: 'Активна',
+    },
+    {
+      id: 'fallback-sub-4',
+      userId: '44444444-4444-4444-a444-444444444444',
+      email: 'old@example.com',
+      fullName: 'Отписанный пользователь',
+      role: 'applicant',
+      roleLabel: 'Заявитель',
+      subscribedAt: '01.03.2026, 10:00',
+      unsubscribedAt: '10.03.2026, 10:00',
+      status: 'unsubscribed',
+      statusLabel: 'Отписан',
+    },
+  ];
+}

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-new.html
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-new.html
@@ -18,7 +18,7 @@
   <section class="newsletter-status" aria-live="polite">
     <span>{{ statusMessage() }}</span>
     @if (recipientsCount() !== null) {
-    <strong>{{ estimating() ? 'Расчёт...' : 'Получателей: ' + recipientsCount() }}</strong>
+    <strong>{{ estimating() ? 'Расчёт...' : recipientsCountLabel(recipientsCount()) }}</strong>
     }
   </section>
 
@@ -82,7 +82,7 @@
             (change)="setAudienceMode('selected')" />
           <span>
             <strong>Выбранные вручную</strong>
-            <small>Сейчас выбрано адресов: {{ selectedCount() }}.</small>
+            <small>Выбрано: {{ selectedAddressLabel() }}.</small>
           </span>
         </label>
       </div>
@@ -148,7 +148,7 @@
         <h3>Подтвердите отправку</h3>
       </header>
       <p>
-        Письмо «{{ subject() }}» будет отправлено получателям: {{ recipientsCount() ?? 0 }}.
+        Письмо «{{ subject() }}» будет отправлено. Аудитория: {{ recipientsCountLabel(recipientsCount()) }}.
       </p>
       <div class="newsletter-form__actions">
         <button type="button" class="newsletter-btn newsletter-btn--ghost" [disabled]="sending()" (click)="closeConfirm()">

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-new.ts
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-new.ts
@@ -43,6 +43,9 @@ export class NewsletterNew {
     if (this.audienceMode() === 'selected' && this.selectedCount() === 0) return false;
     return true;
   });
+  protected readonly selectedAddressLabel = computed(() =>
+    formatCount(this.selectedCount(), ['адрес', 'адреса', 'адресов']),
+  );
 
   constructor() {
     if (this.selectedCount() > 0) {
@@ -163,8 +166,32 @@ export class NewsletterNew {
     }
     return true;
   }
+
+  protected recipientsCountLabel(count: number | null): string {
+    return formatCount(count ?? 0, ['получатель', 'получателя', 'получателей']);
+  }
 }
 
 function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback;
+}
+
+function formatCount(count: number, forms: [string, string, string]): string {
+  const absCount = Math.abs(count);
+  const lastTwoDigits = absCount % 100;
+  const lastDigit = absCount % 10;
+
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 14) {
+    return `${count} ${forms[2]}`;
+  }
+
+  if (lastDigit === 1) {
+    return `${count} ${forms[0]}`;
+  }
+
+  if (lastDigit >= 2 && lastDigit <= 4) {
+    return `${count} ${forms[1]}`;
+  }
+
+  return `${count} ${forms[2]}`;
 }

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-sender-profile.service.ts
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-sender-profile.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, inject } from '@angular/core';
+import { buildRpcBaseUrl } from '@notary-portal/ui';
+import { NewsletterUiStoreService } from './newsletter-ui-store.service';
+
+export interface NewsletterSenderProfile {
+  appName: string;
+  fromEmail: string;
+  host: string;
+  port: number | null;
+  transport: string;
+  configured: boolean;
+  source: 'api' | 'mock';
+}
+
+@Injectable({ providedIn: 'root' })
+export class NewsletterSenderProfileService {
+  private readonly uiStore = inject(NewsletterUiStoreService);
+
+  async getSenderProfile(): Promise<NewsletterSenderProfile> {
+    try {
+      const response = await fetch(`${buildRpcBaseUrl()}/api/mail/sender-profile`);
+      if (!response.ok) {
+        throw new Error(`Mail sender API returned ${response.status}`);
+      }
+
+      const data = (await response.json()) as Partial<NewsletterSenderProfile>;
+      return {
+        appName: data.appName?.trim() || 'Notary portal',
+        fromEmail: data.fromEmail?.trim() || this.fallbackProfile().fromEmail,
+        host: data.host?.trim() || this.fallbackProfile().host,
+        port: typeof data.port === 'number' ? data.port : this.fallbackProfile().port,
+        transport: data.transport?.trim() || 'smtp',
+        configured: Boolean(data.configured),
+        source: 'api',
+      };
+    } catch {
+      return this.fallbackProfile();
+    }
+  }
+
+  private fallbackProfile(): NewsletterSenderProfile {
+    const profile = this.uiStore.activeSmtpClients()[0];
+
+    return {
+      appName: profile?.fromName || 'Notary portal',
+      fromEmail: profile?.fromEmail || 'noreply@notary-portal.local',
+      host: profile?.host || 'smtp.example.com',
+      port: profile?.port ?? 587,
+      transport: 'smtp',
+      configured: Boolean(profile),
+      source: 'mock',
+    };
+  }
+}

--- a/libs/web/admin/src/lib/features/newsletter/newsletter-sent-messages.service.ts
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter-sent-messages.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { buildRpcBaseUrl } from '@notary-portal/ui';
+
+export interface SentMessageView {
+  id: string;
+  subject: string;
+  bodyText: string;
+  bodyHtml: string;
+  sentAt: string;
+  fromEmail: string;
+  toEmail: string;
+  transport: string;
+  previewUrl: string | null;
+}
+
+export interface SentMessagesResponse {
+  configured: boolean;
+  messages: SentMessageView[];
+  error?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class NewsletterSentMessagesService {
+  async listMessages(): Promise<SentMessagesResponse> {
+    const response = await fetch(`${buildRpcBaseUrl()}/api/mail/messages`);
+
+    if (!response.ok) {
+      return {
+        configured: false,
+        messages: [],
+        error: `Журнал писем вернул статус ${response.status}.`,
+      };
+    }
+
+    const data = (await response.json()) as Partial<SentMessagesResponse>;
+
+    return {
+      configured: Boolean(data.configured),
+      messages: Array.isArray(data.messages) ? data.messages : [],
+      error: data.error,
+    };
+  }
+}

--- a/libs/web/admin/src/lib/features/newsletter/newsletter.mock.ts
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter.mock.ts
@@ -1,0 +1,197 @@
+export type NewsletterItemStatus = 'sent' | 'draft' | 'scheduled';
+
+export interface NewsletterItem {
+  id: string;
+  subject: string;
+  sentAt: string;
+  recipientCount: number;
+  status: NewsletterItemStatus;
+  previewText: string;
+  recipients: string[];
+  previewUrl?: string | null;
+}
+
+export const MOCK_NEWSLETTERS: NewsletterItem[] = [
+  {
+    id: 'newsletter-001',
+    subject: 'Мартовское обновление тарифов для нотариусов',
+    sentAt: '2026-03-22T09:30:00.000Z',
+    recipientCount: 248,
+    status: 'sent',
+    previewText:
+      'Здравствуйте! Сообщаем об обновлении тарифных планов и расширении лимитов для нотариальных кабинетов. Новые условия начнут действовать с 1 апреля.',
+    recipients: [
+      'ivan.petrov@notary.local',
+      'anna.smirnova@notary.local',
+      'office-12@notary.local',
+      'mikhail.kuznetsov@notary.local',
+      'elena.volkova@notary.local',
+      'support-office@notary.local',
+    ],
+  },
+  {
+    id: 'newsletter-002',
+    subject: 'Памятка заявителю: подготовка документов',
+    sentAt: '2026-03-19T12:10:00.000Z',
+    recipientCount: 614,
+    status: 'sent',
+    previewText:
+      'Перед подачей заявки проверьте паспортные данные, правоустанавливающие документы и фотографии объекта. Это ускорит первичную проверку.',
+    recipients: [
+      'client-001@example.com',
+      'client-014@example.com',
+      'client-027@example.com',
+      'client-048@example.com',
+      'client-063@example.com',
+      'client-088@example.com',
+    ],
+  },
+  {
+    id: 'newsletter-003',
+    subject: 'Запланированное обслуживание портала',
+    sentAt: '2026-03-28T18:00:00.000Z',
+    recipientCount: 902,
+    status: 'scheduled',
+    previewText:
+      'В ночь с пятницы на субботу будет выполнено техническое обслуживание. Личные кабинеты могут быть недоступны до 30 минут.',
+    recipients: [
+      'admin-team@notary.local',
+      'notary-archive@notary.local',
+      'client-104@example.com',
+      'client-205@example.com',
+      'client-306@example.com',
+      'client-407@example.com',
+    ],
+  },
+  {
+    id: 'newsletter-004',
+    subject: 'Черновик: инструкция по оплате подписки',
+    sentAt: '2026-03-25T14:00:00.000Z',
+    recipientCount: 0,
+    status: 'draft',
+    previewText:
+      'Опишите шаги оплаты подписки, проверку статуса транзакции и получение закрывающих документов после успешного платежа.',
+    recipients: [],
+  },
+  {
+    id: 'newsletter-005',
+    subject: 'Новые статусы заявок на оценку',
+    sentAt: '2026-03-16T08:45:00.000Z',
+    recipientCount: 311,
+    status: 'sent',
+    previewText:
+      'В карточке заявки появились дополнительные статусы проверки документов. Теперь заявитель и нотариус видят более точный этап обработки.',
+    recipients: [
+      'notary-01@example.com',
+      'notary-02@example.com',
+      'notary-03@example.com',
+      'notary-04@example.com',
+      'notary-05@example.com',
+      'notary-06@example.com',
+    ],
+  },
+  {
+    id: 'newsletter-006',
+    subject: 'Напоминание о незавершённых заявках',
+    sentAt: '2026-03-29T07:15:00.000Z',
+    recipientCount: 126,
+    status: 'scheduled',
+    previewText:
+      'У вас есть заявки, которые ожидают загрузки документов или подтверждения параметров объекта недвижимости.',
+    recipients: [
+      'client-151@example.com',
+      'client-152@example.com',
+      'client-153@example.com',
+      'client-154@example.com',
+      'client-155@example.com',
+      'client-156@example.com',
+    ],
+  },
+  {
+    id: 'newsletter-007',
+    subject: 'Черновик: обзор новой панели администратора',
+    sentAt: '2026-03-24T10:00:00.000Z',
+    recipientCount: 0,
+    status: 'draft',
+    previewText:
+      'Кратко расскажите администраторам о новых разделах: пользователи, заказы, платежи, рассылки и мониторинг безопасности.',
+    recipients: [],
+  },
+  {
+    id: 'newsletter-008',
+    subject: 'Итоги недели: обработанные оценки',
+    sentAt: '2026-03-15T15:20:00.000Z',
+    recipientCount: 57,
+    status: 'sent',
+    previewText:
+      'За неделю обработано 57 заявок на оценку. Среднее время проверки документов снизилось, а количество повторных загрузок уменьшилось.',
+    recipients: [
+      'admin-analytics@notary.local',
+      'chief-notary@notary.local',
+      'region-ural@notary.local',
+      'region-volga@notary.local',
+      'region-siberia@notary.local',
+    ],
+  },
+  {
+    id: 'newsletter-009',
+    subject: 'Обновление политики хранения файлов',
+    sentAt: '2026-03-14T11:05:00.000Z',
+    recipientCount: 734,
+    status: 'sent',
+    previewText:
+      'Мы обновили правила хранения загруженных PDF и изображений. Документы остаются доступны в личном кабинете в соответствии с регламентом.',
+    recipients: [
+      'client-211@example.com',
+      'client-212@example.com',
+      'client-213@example.com',
+      'client-214@example.com',
+      'client-215@example.com',
+      'client-216@example.com',
+    ],
+  },
+  {
+    id: 'newsletter-010',
+    subject: 'Подборка частых вопросов по заявкам',
+    sentAt: '2026-03-31T13:30:00.000Z',
+    recipientCount: 419,
+    status: 'scheduled',
+    previewText:
+      'Собрали ответы на частые вопросы о сроках рассмотрения, форматах документов, оплате и получении результата оценки.',
+    recipients: [
+      'client-301@example.com',
+      'client-302@example.com',
+      'client-303@example.com',
+      'client-304@example.com',
+      'client-305@example.com',
+      'client-306@example.com',
+    ],
+  },
+  {
+    id: 'newsletter-011',
+    subject: 'Черновик: повторная активация подписчиков',
+    sentAt: '2026-03-27T09:00:00.000Z',
+    recipientCount: 0,
+    status: 'draft',
+    previewText:
+      'Подготовьте мягкое письмо для пользователей, которые давно не заходили в личный кабинет и могут вернуться к незавершённым заявкам.',
+    recipients: [],
+  },
+  {
+    id: 'newsletter-012',
+    subject: 'Безопасность аккаунта: проверьте доступы',
+    sentAt: '2026-03-12T06:40:00.000Z',
+    recipientCount: 895,
+    status: 'sent',
+    previewText:
+      'Рекомендуем проверить актуальность пароля, контактного email и список активных сессий в личном кабинете.',
+    recipients: [
+      'client-401@example.com',
+      'client-402@example.com',
+      'client-403@example.com',
+      'client-404@example.com',
+      'client-405@example.com',
+      'client-406@example.com',
+    ],
+  },
+];

--- a/libs/web/admin/src/lib/features/newsletter/newsletter.scss
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter.scss
@@ -71,6 +71,60 @@
   white-space: nowrap;
 }
 
+.newsletter-status--embedded {
+  margin: 0 20px 18px;
+  box-shadow: none;
+}
+
+.newsletter-sender-card {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(320px, 0.9fr);
+  gap: 18px;
+  align-items: center;
+  padding: 18px 20px;
+  border: 1px solid var(--admin-border, #e2e8f0);
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: var(--admin-shadow-soft, 0 10px 24px rgb(15 23 42 / 6%));
+}
+
+.newsletter-sender-card h3,
+.newsletter-detail-section h4 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+.newsletter-sender-card p {
+  margin: 8px 0 0;
+  color: var(--admin-text-soft, #475569);
+}
+
+.newsletter-sender-card dl,
+.newsletter-detail-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.newsletter-sender-card dl {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.newsletter-sender-card dt,
+.newsletter-detail-list dt {
+  color: var(--admin-text-muted, #64748b);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.newsletter-sender-card dd,
+.newsletter-detail-list dd {
+  margin: 4px 0 0;
+  color: var(--admin-text, #0f172a);
+  overflow-wrap: anywhere;
+}
+
 .newsletter-tabs {
   display: flex;
   gap: 8px;
@@ -116,6 +170,14 @@
   border-bottom: 0;
 }
 
+.newsletter-panel__header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 .newsletter-panel__footer--end {
   justify-content: flex-end;
 }
@@ -131,6 +193,31 @@
 
 .newsletter-filters--history {
   grid-template-columns: minmax(240px, 1fr) auto;
+}
+
+.newsletter-filters--list {
+  grid-template-columns: minmax(220px, 280px);
+}
+
+.newsletter-summary {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.newsletter-summary span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--admin-border, #e2e8f0);
+  border-radius: 999px;
+  color: var(--admin-text-soft, #475569);
+  background: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .newsletter-field {
@@ -246,10 +333,39 @@
   width: 48px;
 }
 
+.newsletter-table__row {
+  cursor: pointer;
+}
+
+.newsletter-table__row:hover,
+.newsletter-table__row:focus {
+  background: #fff7f7;
+  outline: 0;
+}
+
 .newsletter-table__email,
 .newsletter-table__subject {
   font-weight: 700;
   word-break: break-word;
+}
+
+.newsletter-table__subject a {
+  color: var(--admin-text, #0f172a);
+  text-decoration: none;
+}
+
+.newsletter-table__subject a:hover {
+  color: var(--admin-accent, #dc2626);
+  text-decoration: underline;
+}
+
+.newsletter-table__subject small {
+  display: block;
+  max-width: 620px;
+  margin-top: 5px;
+  color: var(--admin-text-soft, #475569);
+  font-weight: 400;
+  line-height: 1.45;
 }
 
 .newsletter-empty {
@@ -390,17 +506,138 @@
   margin-bottom: 0;
 }
 
+.newsletter-detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 990;
+  background: rgb(15 23 42 / 32%);
+}
+
+.newsletter-detail-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  width: min(430px, 100vw);
+  height: 100vh;
+  overflow-y: auto;
+  border-left: 1px solid var(--admin-border, #e2e8f0);
+  background: #fff;
+  box-shadow: -20px 0 60px rgb(15 23 42 / 22%);
+}
+
+.newsletter-detail-panel__header,
+.newsletter-detail-panel__footer {
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--admin-border, #e2e8f0);
+}
+
+.newsletter-detail-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.newsletter-detail-panel__header h3 {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.newsletter-detail-panel__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: auto;
+  border-top: 1px solid var(--admin-border, #e2e8f0);
+  border-bottom: 0;
+}
+
+.newsletter-detail-list,
+.newsletter-detail-section {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--admin-border, #e2e8f0);
+}
+
+.newsletter-detail-list {
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+
+.newsletter-detail-list div {
+  min-width: 0;
+}
+
+.newsletter-detail-list dd strong,
+.newsletter-detail-list dd small {
+  display: block;
+}
+
+.newsletter-detail-list dd small,
+.newsletter-detail-note {
+  color: var(--admin-text-soft, #475569);
+}
+
+.newsletter-detail-link {
+  color: var(--admin-accent, #dc2626);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.newsletter-detail-link:hover {
+  text-decoration: underline;
+}
+
+.newsletter-detail-section h4 {
+  font-size: 14px;
+}
+
+.newsletter-recipient-list {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.newsletter-recipient-list li {
+  padding: 9px 10px;
+  border: 1px solid var(--admin-border, #e2e8f0);
+  border-radius: 8px;
+  background: var(--admin-surface-alt, #f8fafc);
+  overflow-wrap: anywhere;
+}
+
+.newsletter-detail-note,
+.newsletter-detail-preview {
+  margin: 12px 0 0;
+  line-height: 1.55;
+}
+
+.newsletter-detail-preview {
+  color: var(--admin-text, #0f172a);
+}
+
 @media (max-width: 980px) {
   .newsletter-page__hero,
   .newsletter-panel__header,
   .newsletter-panel__footer,
-  .newsletter-status {
+  .newsletter-panel__header-actions,
+  .newsletter-status,
+  .newsletter-sender-card {
     align-items: stretch;
     flex-direction: column;
   }
 
   .newsletter-filters,
   .newsletter-filters--history,
+  .newsletter-filters--list,
+  .newsletter-sender-card,
+  .newsletter-sender-card dl,
   .newsletter-compose {
     grid-template-columns: 1fr;
   }
@@ -409,5 +646,17 @@
   .newsletter-form__actions,
   .newsletter-pagination {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .newsletter-detail-panel {
+    width: 100vw;
+  }
+
+  .newsletter-detail-panel__header,
+  .newsletter-detail-panel__footer {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/libs/web/admin/src/lib/features/newsletter/newsletter.spec.ts
+++ b/libs/web/admin/src/lib/features/newsletter/newsletter.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { Router } from '@angular/router';
 import { NewsletterApiService } from './newsletter-api.service';
+import { NewsletterSentMessagesService } from './newsletter-sent-messages.service';
 import { NewsletterSelectionService } from './newsletter-selection.service';
 import { NewsletterNew } from './newsletter-new';
-import { Newsletter } from './newsletter';
+import { NewsletterListComponent } from './newsletter-list/newsletter-list';
+import { NewsletterSenderProfileService } from './newsletter-sender-profile.service';
 import type {
   NewsletterCampaignView,
   NewsletterSubscriberView,
@@ -57,9 +59,67 @@ describe('Newsletter admin feature', () => {
     estimateAudience: jest.fn(),
     sendCampaign: jest.fn(),
   };
+  const router = {
+    navigate: jest.fn().mockResolvedValue(true),
+  };
+  const senderProfile = {
+    getSenderProfile: jest.fn().mockResolvedValue({
+      appName: 'Notary portal',
+      fromEmail: 'noreply@test.local',
+      host: 'smtp.ethereal.email',
+      port: 2525,
+      transport: 'smtp',
+      configured: true,
+      source: 'api',
+    }),
+  };
+  const sentMessages = {
+    listMessages: jest.fn().mockResolvedValue({
+      configured: true,
+      messages: [
+        {
+          id: 'sent-1',
+          subject: 'Проверка SMTP',
+          bodyText: 'Здравствуйте, Нотариус Тестовый!\n\nОсновной текст письма\n\n— Notary portal',
+          bodyHtml: '<p>Основной текст письма</p>',
+          sentAt: '2026-03-22T09:30:00.000Z',
+          fromEmail: 'noreply@test.local',
+          toEmail: 'notary@example.com',
+          transport: 'smtp',
+          previewUrl: 'https://ethereal.email/message/test-message',
+        },
+      ],
+    }),
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    router.navigate.mockResolvedValue(true);
+    senderProfile.getSenderProfile.mockResolvedValue({
+      appName: 'Notary portal',
+      fromEmail: 'noreply@test.local',
+      host: 'smtp.ethereal.email',
+      port: 2525,
+      transport: 'smtp',
+      configured: true,
+      source: 'api',
+    });
+    sentMessages.listMessages.mockResolvedValue({
+      configured: true,
+      messages: [
+        {
+          id: 'sent-1',
+          subject: 'Проверка SMTP',
+          bodyText: 'Здравствуйте, Нотариус Тестовый!\n\nОсновной текст письма\n\n— Notary portal',
+          bodyHtml: '<p>Основной текст письма</p>',
+          sentAt: '2026-03-22T09:30:00.000Z',
+          fromEmail: 'noreply@test.local',
+          toEmail: 'notary@example.com',
+          transport: 'smtp',
+          previewUrl: 'https://ethereal.email/message/test-message',
+        },
+      ],
+    });
     api.listSubscribers.mockResolvedValue({
       subscribers,
       meta: { totalItems: 2, totalPages: 1, currentPage: 1, perPage: 10 },
@@ -77,50 +137,92 @@ describe('Newsletter admin feature', () => {
     });
 
     await TestBed.configureTestingModule({
-      imports: [Newsletter, NewsletterNew],
+      imports: [NewsletterListComponent, NewsletterNew],
       providers: [
-        provideRouter([]),
+        { provide: Router, useValue: router },
         NewsletterSelectionService,
         { provide: NewsletterApiService, useValue: api },
+        { provide: NewsletterSenderProfileService, useValue: senderProfile },
+        { provide: NewsletterSentMessagesService, useValue: sentMessages },
       ],
     }).compileComponents();
   });
 
-  it('renders subscribers and applies filters through API', async () => {
-    const fixture = TestBed.createComponent(Newsletter);
+  it('renders sent messages from the mail API in the journal table', async () => {
+    const fixture = TestBed.createComponent(NewsletterListComponent);
     await settle(fixture);
 
-    expect(fixture.nativeElement.textContent).toContain('notary@example.com');
-    expect(fixture.nativeElement.textContent).toContain('old@example.com');
+    expect(fixture.nativeElement.textContent).toContain('Журнал писем');
+    expect(fixture.nativeElement.textContent).toContain('noreply@test.local');
+    expect(fixture.nativeElement.textContent).toContain('Проверка SMTP');
+    expect(fixture.nativeElement.textContent).toContain('Мартовское обновление тарифов');
 
-    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[type="search"]');
-    input.value = 'notary@example.com';
-    input.dispatchEvent(new Event('input'));
-    const applyButton = Array.from<HTMLButtonElement>(
-      fixture.nativeElement.querySelectorAll('button'),
-    ).find((button) => button.textContent?.includes('Применить')) as HTMLButtonElement;
-    applyButton.click();
+    const select: HTMLSelectElement = fixture.nativeElement.querySelector('select');
+    select.value = 'sent';
+    select.dispatchEvent(new Event('change'));
     await settle(fixture);
 
-    expect(api.listSubscribers).toHaveBeenLastCalledWith(
-      expect.objectContaining({ query: 'notary@example.com' }),
-    );
+    expect(fixture.nativeElement.textContent).toContain('Проверка SMTP');
   });
 
-  it('keeps selected subscribers for the new campaign route', async () => {
-    const listFixture = TestBed.createComponent(Newsletter);
+  it('opens message detail panel and repeats sending', async () => {
+    const fixture = TestBed.createComponent(NewsletterListComponent);
+    await settle(fixture);
+
+    const firstRow: HTMLTableRowElement = fixture.nativeElement.querySelector(
+      '.newsletter-table--campaigns tbody tr',
+    );
+    firstRow.click();
+    await settle(fixture);
+
+    expect(fixture.nativeElement.textContent).toContain('Детали письма');
+    expect(fixture.nativeElement.textContent).toContain('notary@example.com');
+
+    const repeatButton = Array.from<HTMLButtonElement>(
+      fixture.nativeElement.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('Отправить повторно')) as HTMLButtonElement;
+    repeatButton.click();
+    await settle(fixture);
+
+    expect(fixture.nativeElement.textContent).toContain('Повторная отправка письма');
+  });
+
+  it('keeps checked recipients for Karlov newsletter form', async () => {
+    const listFixture = TestBed.createComponent(NewsletterListComponent);
     await settle(listFixture);
 
+    expect(listFixture.nativeElement.textContent).toContain('Получатели для новой рассылки');
     const firstCheckbox: HTMLInputElement = listFixture.nativeElement.querySelector(
-      'tbody input[type="checkbox"]',
+      '.newsletter-table--subscribers tbody input[type="checkbox"]',
     );
     firstCheckbox.click();
     await settle(listFixture);
 
+    const selectedButton = Array.from<HTMLButtonElement>(
+      listFixture.nativeElement.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('Использовать выбранных')) as HTMLButtonElement;
+    selectedButton.click();
+    await settle(listFixture);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/admin/newsletter/new']);
+
     const newFixture = TestBed.createComponent(NewsletterNew);
     await settle(newFixture);
 
-    expect(newFixture.nativeElement.textContent).toContain('Сейчас выбрано адресов: 1');
+    expect(newFixture.nativeElement.textContent).toContain('Выбрано: 1 адрес');
+  });
+
+  it('routes create button to Karlov newsletter form', async () => {
+    const fixture = TestBed.createComponent(NewsletterListComponent);
+    await settle(fixture);
+
+    const createButton = Array.from<HTMLButtonElement>(
+      fixture.nativeElement.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('Создать рассылку')) as HTMLButtonElement;
+    createButton.click();
+    await settle(fixture);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/admin/newsletter/new']);
   });
 
   it('opens sanitized preview and confirmation before sending', async () => {


### PR DESCRIPTION
- добавлена страница /admin/newsletter со списком рассылок
- добавлена фильтрация писем по статусу
- добавлена боковая панель с деталями письма
- сохранён выбор получателей через чекбоксы для формы создания рассылки
- добавлено отображение отправленных SMTP-писем вместе с mock-данными
- добавлено хранение отправленных SMTP-писем во внутреннем журнале backend
- исправлены счётчики, склонения и превью текста письма
- обновлены тесты для страницы рассылок