### PR TITLE
feat: add Loki log dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ FRONTEND_URL=http://localhost:4200
 # Если не задано: NODE_ENV=production использует info, остальные окружения используют debug.
 LOG_LEVEL=info
 
+# Grafana (docker-compose)
+GF_ADMIN_PASSWORD=admin
+
 # Почта: SMTP и/или EmailJS (см. MAIL_TRANSPORT).
 # PASSWORD_RESET_BASE_URL=http://localhost:4200
 # PASSWORD_RESET_TTL_SEC=3600

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ### Запуск проекта
 
-- `docker-compose up` - запустить PostgreSQL
+- `docker-compose up` - запустить PostgreSQL, MinIO, Prometheus, Loki, Promtail и Grafana
 - `pnpm nx prune` - очистка nx
 - `docker system prune` - Глубокая чистка и освободить максимум места
 - `docker container prune` - Удаляет только остановленные контейнеры
@@ -53,6 +53,20 @@
 | **`ENOSPC` / no space left on device** при сборке | `df -h`, `docker system df`, при необходимости `docker builder prune -af` или `docker system prune -af`. |
 | **`i/o timeout`** у `docker compose` | `export COMPOSE_HTTP_TIMEOUT=300` (Linux); отдельно `compose build`, затем `up -d` без `--build`; см. [apps/web/DOCKER.md](apps/web/DOCKER.md). |
 | **`EAI_AGAIN` / registry.npmjs.org** в логах сборки | DNS/сеть хоста или `/etc/docker/daemon.json` → `dns`. |
+
+---
+
+### Логи в Grafana
+
+Корневой [`docker-compose.yaml`](docker-compose.yaml) поднимает **Loki** и **Promtail** вместе с Grafana. Promtail читает stdout Docker-контейнеров через `/var/run/docker.sock`, поэтому в Grafana (`http://localhost:3001`, `admin` / `GF_ADMIN_PASSWORD` или `admin`) доступен datasource **Loki** и дашборд **Container logs**.
+
+Для API, запущенного в Docker, структурированные JSON-логи фильтруются по `app`, `environment`, `level` и `requestId`. В Explore можно использовать запрос:
+
+```logql
+{job="docker", app="api"} | json | requestId="<id запроса>"
+```
+
+Если API запущен локально через `pnpm nx serve api`, его stdout не читается Promtail; для логов в Grafana запускайте API как контейнер, например через [`apps/web/docker-compose.portal.yml`](apps/web/docker-compose.portal.yml).
 
 ---
 
@@ -100,4 +114,3 @@
 - `netsh int ipv4 show excludedportrange protocol=tcp` - просмотр списка зарезервированных портов.
 - `netsh int ipv4 delete excludedportrange protocol=tcp startport=2182 numberofports=10` - исключение портов.
 - `net stop winnat` | `net start winnat` - остановка и запуск службы winnat для сброза зарезервированных портов.
-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,31 @@ services:
       - '--web.enable-lifecycle'
     restart: unless-stopped
 
+  loki:
+    image: grafana/loki:3.2.1
+    container_name: notary-loki
+    ports:
+      - '3100:3100'
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/config.yml:ro
+      - loki_data:/loki
+    command:
+      - '-config.file=/etc/loki/config.yml'
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:3.2.1
+    container_name: notary-promtail
+    volumes:
+      - ./monitoring/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail_positions:/tmp
+    command:
+      - '-config.file=/etc/promtail/config.yml'
+    depends_on:
+      - loki
+    restart: unless-stopped
+
   grafana:
     image: grafana/grafana:11.3.0
     container_name: notary-grafana
@@ -54,6 +79,7 @@ services:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
+      - loki
     restart: unless-stopped
 
   minio:
@@ -86,5 +112,7 @@ services:
 volumes:
   notary_data:
   prometheus_data:
+  loki_data:
+  promtail_positions:
   grafana_data:
   minio_data:

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -25,7 +25,7 @@
 docker info
 ```
 
-2. Поднимите инфраструктуру (PostgreSQL, MinIO, при необходимости — Prometheus и Grafana):
+2. Поднимите инфраструктуру (PostgreSQL, MinIO, Prometheus, Loki, Promtail и Grafana):
 
    ```bash
    docker-compose up
@@ -37,6 +37,8 @@ docker info
 
    Для мониторинга метрик вместе с БД поднимаются сервисы **Prometheus** (порт 9090), **Grafana** (порт 3001) и **postgres_exporter** (порт 9187, метрики PostgreSQL). Источник данных Prometheus и дашборды «System metrics», «Business metrics» и «PostgreSQL» подключаются автоматически (provisioning). Логин Grafana по умолчанию: `admin`, пароль задаётся переменной `GF_ADMIN_PASSWORD` (по умолчанию `admin`). Чтобы Prometheus собирал метрики с API, запустите API на хосте (`pnpm nx serve api`); в конфиге используется `host.docker.internal:3000`.
 
+   Для просмотра технических логов поднимаются **Loki** (порт 3100) и **Promtail**. Promtail читает stdout Docker-контейнеров через `/var/run/docker.sock`, отправляет логи в Loki и добавляет метки `job`, `app`, `environment`, `level`, `service`. В Grafana автоматически появляется datasource **Loki** и дашборд **Container logs**. Если API запущен в Docker (`apps/web/docker-compose.portal.yml`), его JSON-логи можно фильтровать по уровню и `requestId`; если API запущен на хосте через `pnpm nx serve api`, эти stdout-логи в Loki не попадут.
+
 3. В отдельном терминале запустите Front-end:
 
 ```bash
@@ -46,7 +48,7 @@ pnpm nx serve web
 ## Примечания
 
 - Если порт `5432` занят (например, установлен PostgreSQL вне Docker), измените порт в `docker-compose.yaml` на свободный.
-- **Мониторинг:** API отдаёт эндпоинты `/health` (проверка БД) и `/metrics` (метрики в формате Prometheus). После запуска `docker-compose up` откройте Grafana на http://localhost:3001 и используйте дашборды «System metrics», «Business metrics» и «PostgreSQL» (метрики БД через postgres_exporter).
+- **Мониторинг:** API отдаёт эндпоинты `/health` (проверка БД) и `/metrics` (метрики в формате Prometheus). После запуска `docker-compose up` откройте Grafana на http://localhost:3001 и используйте дашборды «System metrics», «Business metrics», «PostgreSQL» и «Container logs» (логи через Loki/Promtail). В Explore можно выбрать datasource **Loki** и выполнить запрос `{job="docker", app="api"} | json | requestId="<id запроса>"`.
 
 ## Создание компонента
 

--- a/monitoring/grafana/provisioning/dashboards/logs.json
+++ b/monitoring/grafana/provisioning/dashboards/logs.json
@@ -1,0 +1,258 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({job=\"docker\", app=~\"$app\", environment=~\"$environment\"} | json | level=~\"error|fatal\" [$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors and fatal logs",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({job=\"docker\", app=~\"$app\", environment=~\"$environment\"} | json | requestId=~\"$requestId\" [$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs matching request ID",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 75,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 8,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (level) (count_over_time({job=\"docker\", app=~\"$app\", environment=~\"$environment\"} | json | level=~\"$level\" [$__range]))",
+          "legendFormat": "{{level}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log count by level",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 8 },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{job=\"docker\", app=~\"$app\", environment=~\"$environment\"} | json | level=~\"$level\" | requestId=~\"$requestId\" |~ \"$search\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Structured container logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["notarius", "logs", "loki"],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "loki", "uid": "loki" },
+        "definition": "label_values({job=\"docker\"}, app)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "App",
+        "multi": false,
+        "name": "app",
+        "options": [],
+        "query": "label_values({job=\"docker\"}, app)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "loki", "uid": "loki" },
+        "definition": "label_values({job=\"docker\"}, environment)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": "label_values({job=\"docker\"}, environment)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": "trace|debug|info|warn|error|fatal",
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Level",
+        "multi": false,
+        "name": "level",
+        "options": [],
+        "query": "trace,debug,info,warn,error,fatal",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": { "selected": false, "text": ".*", "value": ".*" },
+        "hide": 0,
+        "label": "Request ID regex",
+        "name": "requestId",
+        "options": [],
+        "query": ".*",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": { "selected": false, "text": ".*", "value": ".*" },
+        "hide": 0,
+        "label": "Text regex",
+        "name": "search",
+        "options": [],
+        "query": ".*",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Container logs",
+  "uid": "notarius-logs",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,4 +1,5 @@
-# Grafana datasources provisioning. Prometheus is used by dashboards.
+# Grafana datasources provisioning. Prometheus is used by metrics dashboards,
+# Loki is used by the logs dashboard and Explore.
 apiVersion: 1
 datasources:
   - name: Prometheus
@@ -7,4 +8,10 @@ datasources:
     access: proxy
     url: http://prometheus:9090
     isDefault: true
+    editable: false
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
     editable: false

--- a/monitoring/loki/loki-config.yml
+++ b/monitoring/loki/loki-config.yml
@@ -1,0 +1,45 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+analytics:
+  reporting_enabled: false

--- a/monitoring/promtail/promtail-config.yml
+++ b/monitoring/promtail/promtail-config.yml
@@ -1,0 +1,38 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/promtail-positions.yml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - target_label: job
+        replacement: docker
+      - source_labels: [__meta_docker_container_name]
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: app
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+    pipeline_stages:
+      - docker: {}
+      - json:
+          expressions:
+            level: level
+            service: service
+            environment: env
+            requestId: requestId
+            message: msg
+      - labels:
+          level:
+          service:
+          environment:


### PR DESCRIPTION
## Summary
- add Loki and Promtail services to docker-compose
- provision Loki datasource and Container logs Grafana dashboard
- document how to open and query logs

## Checks
- node JSON parse for Grafana dashboard
- Ruby YAML parse for compose/provisioning configs
- docker compose -f docker-compose.yaml config --quiet
- local smoke test with Docker logs through Promtail -> Loki -> Grafana