### PR TITLE
feat(newsletter): добавить метрики и дашборд Grafana

### DIFF
--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
@@ -51,11 +51,17 @@ describe('NewsletterService', () => {
     warn: jest.fn(),
     error: jest.fn(),
   };
+  const metricsService = {
+    recordNewsletterCampaignStarted: jest.fn(),
+    recordNewsletterDelivery: jest.fn(),
+    recordNewsletterCampaignCompleted: jest.fn(),
+  };
   const service = new NewsletterService(
     repository as never,
     mailer as never,
     auditService as never,
     notificationService as never,
+    metricsService as never,
   );
 
   beforeEach(() => {
@@ -117,6 +123,9 @@ describe('NewsletterService', () => {
     mailer.sendNewsletterEmail.mockResolvedValue(undefined);
     auditService.record.mockResolvedValue(undefined);
     notificationService.createNotification.mockResolvedValue(undefined);
+    metricsService.recordNewsletterCampaignStarted.mockReturnValue(undefined);
+    metricsService.recordNewsletterDelivery.mockReturnValue(undefined);
+    metricsService.recordNewsletterCampaignCompleted.mockReturnValue(undefined);
   });
 
   it('normalizes subscriber search, role, status and pagination for admins', async () => {
@@ -254,6 +263,11 @@ describe('NewsletterService', () => {
     );
     expect(logger.warn).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();
+    expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('all', 2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(1, 'sent');
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(2, 'sent');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith('all', 'sent');
     expect(response.campaign?.sentCount).toBe(2);
   });
 
@@ -298,6 +312,11 @@ describe('NewsletterService', () => {
       message:
         'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 1 из 2, ошибок 1.',
     });
+    expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('all', 2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(1, 'sent');
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(2, 'failed');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith('all', 'partial_failed');
   });
 
   it('marks campaign as failed when all deliveries fail', async () => {
@@ -323,6 +342,10 @@ describe('NewsletterService', () => {
       message:
         'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 0 из 1, ошибок 1.',
     });
+    expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('all', 1);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(1);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledWith('failed');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith('all', 'failed');
   });
 
   it('rejects empty audience and invalid body before sending', async () => {
@@ -349,6 +372,9 @@ describe('NewsletterService', () => {
     expect(logger.log).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();
+    expect(metricsService.recordNewsletterCampaignStarted).not.toHaveBeenCalled();
+    expect(metricsService.recordNewsletterDelivery).not.toHaveBeenCalled();
+    expect(metricsService.recordNewsletterCampaignCompleted).not.toHaveBeenCalled();
   });
 
   it('finalizes the campaign when delivery persistence breaks unexpectedly', async () => {
@@ -381,6 +407,11 @@ describe('NewsletterService', () => {
       message:
         'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 2 из 2, ошибок 0.',
     });
+    expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('all', 2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(1, 'sent');
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(2, 'sent');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith('all', 'partial_failed');
   });
 });
 

--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
@@ -3,6 +3,7 @@ import { Code, ConnectError } from '@connectrpc/connect';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { AuditService } from '@internal/audit';
 import { Role, requireRole, type AccessTokenPayload } from '@internal/auth-shared';
+import { MetricsService, type NewsletterAudienceMetricType, type NewsletterCampaignMetricStatus } from '@internal/metrics';
 import { NotificationService } from '@internal/notification';
 import {
   EstimateNewsletterAudienceResponseSchema,
@@ -57,6 +58,7 @@ export class NewsletterService {
     @Inject(NEWSLETTER_MAILER) private readonly newsletterMailer: NewsletterMailer,
     private readonly auditService: AuditService,
     private readonly notificationService: NotificationService,
+    private readonly metricsService: MetricsService,
   ) {}
 
   listNewsletterSubscribers(
@@ -105,6 +107,7 @@ export class NewsletterService {
   ): Promise<SendNewsletterCampaignResponse> {
     const actor = requireRole(Role.Admin);
     const audience = this.normalizeAudience(request.audience);
+    const audienceMetricType = toMetricAudienceType(audience.type);
     const subject = normalizeRequiredString(request.subject, 'subject', MAX_SUBJECT_LENGTH);
     const bodyHtml = normalizeBodyHtml(request.bodyHtml);
     const recipients = await this.newsletterRepository.resolveAudience(audience);
@@ -123,6 +126,7 @@ export class NewsletterService {
     });
 
     this.logCampaignStart(campaign.id, subject, campaign.audienceLabel, recipients.length);
+    this.metricsService.recordNewsletterCampaignStarted(audienceMetricType, recipients.length);
     await this.recordCampaignAuditBestEffort({
       actor,
       campaign,
@@ -148,6 +152,7 @@ export class NewsletterService {
         } catch (error) {
           const deliveryErrorMessage = normalizeErrorMessage(error);
           failedCount += 1;
+          this.metricsService.recordNewsletterDelivery('failed');
           this.logDeliveryFailure(campaign.id, recipient.email, deliveryErrorMessage);
 
           try {
@@ -165,6 +170,7 @@ export class NewsletterService {
         }
 
         sentCount += 1;
+        this.metricsService.recordNewsletterDelivery('sent');
 
         try {
           await this.newsletterRepository.markDeliverySent(campaign.id, recipient.email);
@@ -192,6 +198,10 @@ export class NewsletterService {
     });
 
     this.logCampaignCompletion(campaign.id, finalStatus, sentCount, failedCount);
+    this.metricsService.recordNewsletterCampaignCompleted(
+      audienceMetricType,
+      formatCampaignStatus(finalStatus) as NewsletterCampaignMetricStatus,
+    );
     await this.recordCampaignAuditBestEffort({
       actor,
       campaign: completedCampaign,
@@ -428,6 +438,12 @@ function roleLabel(role: NewsletterAudienceQuery['role']): string {
   if (role === PrismaRole.Admin) return 'Администратор';
   if (role === PrismaRole.Notary) return 'Нотариус';
   return 'Заявитель';
+}
+
+function toMetricAudienceType(type: PrismaNewsletterAudienceType): NewsletterAudienceMetricType {
+  if (type === PrismaNewsletterAudienceType.All) return 'all';
+  if (type === PrismaNewsletterAudienceType.Role) return 'role';
+  return 'selected';
 }
 
 function resolveCampaignStatus(

--- a/libs/api/shared/metrics/src/lib/metrics.service.ts
+++ b/libs/api/shared/metrics/src/lib/metrics.service.ts
@@ -25,6 +25,10 @@ export type PromoDiscountType = 'percent';
 export type PaymentHistoryScope = 'user' | 'all';
 export type MetricsResult = 'success' | 'failed';
 
+export type NewsletterCampaignMetricStatus = 'sending' | 'sent' | 'partial_failed' | 'failed';
+export type NewsletterDeliveryOutcome = 'sent' | 'failed';
+export type NewsletterAudienceMetricType = 'all' | 'role' | 'selected';
+
 export interface BillingPaymentMetricContext {
   actor: BillingPaymentActor;
   scenario: BillingPaymentScenario;
@@ -46,6 +50,9 @@ export class MetricsService {
   private readonly usersRegistered: Counter<string>;
   private readonly auditEventsTotal: Counter<string>;
   private readonly reportsGenerated: Counter<string>;
+  private readonly newsletterCampaignsTotal: Counter<'status' | 'audience_type'>;
+  private readonly newsletterDeliveriesTotal: Counter<'outcome'>;
+  private readonly newsletterRecipientsTotal: Counter<'audience_type'>;
 
   constructor() {
     collectDefaultMetrics({ register: this.register, prefix: PREFIX });
@@ -130,6 +137,27 @@ export class MetricsService {
       help: 'Total number of reports generated',
       registers: [this.register],
     });
+
+    this.newsletterCampaignsTotal = new Counter({
+      name: `${PREFIX}newsletter_campaigns_total`,
+      help: 'Total number of newsletter campaigns by status and audience type',
+      labelNames: ['status', 'audience_type'],
+      registers: [this.register],
+    });
+
+    this.newsletterDeliveriesTotal = new Counter({
+      name: `${PREFIX}newsletter_deliveries_total`,
+      help: 'Total number of newsletter deliveries by outcome',
+      labelNames: ['outcome'],
+      registers: [this.register],
+    });
+
+    this.newsletterRecipientsTotal = new Counter({
+      name: `${PREFIX}newsletter_recipients_total`,
+      help: 'Total number of newsletter recipients targeted by audience type',
+      labelNames: ['audience_type'],
+      registers: [this.register],
+    });
   }
 
   async getMetrics(): Promise<string> {
@@ -205,5 +233,36 @@ export class MetricsService {
 
   recordReportGenerated(): void {
     this.reportsGenerated.inc();
+  }
+
+  recordNewsletterCampaignStarted(
+    audienceType: NewsletterAudienceMetricType,
+    recipientsCount: number,
+  ): void {
+    try {
+      this.newsletterCampaignsTotal.inc({ status: 'sending', audience_type: audienceType });
+      this.newsletterRecipientsTotal.inc({ audience_type: audienceType }, recipientsCount);
+    } catch {
+      // best-effort
+    }
+  }
+
+  recordNewsletterDelivery(outcome: NewsletterDeliveryOutcome): void {
+    try {
+      this.newsletterDeliveriesTotal.inc({ outcome });
+    } catch {
+      // best-effort
+    }
+  }
+
+  recordNewsletterCampaignCompleted(
+    audienceType: NewsletterAudienceMetricType,
+    status: NewsletterCampaignMetricStatus,
+  ): void {
+    try {
+      this.newsletterCampaignsTotal.inc({ status, audience_type: audienceType });
+    } catch {
+      // best-effort
+    }
   }
 }

--- a/monitoring/grafana/provisioning/dashboards/business-metrics.json
+++ b/monitoring/grafana/provisioning/dashboards/business-metrics.json
@@ -259,12 +259,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "increase(notary_newsletter_campaigns_total[24h])",
+          "expr": "notary_newsletter_campaigns_total",
           "legendFormat": "{{audience_type}} / {{status}}",
           "refId": "A"
         }
       ],
-      "title": "Newsletter campaigns (24h)",
+      "title": "Newsletter campaigns total",
       "type": "timeseries"
     },
     {
@@ -279,12 +279,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "increase(notary_newsletter_deliveries_total[24h])",
+          "expr": "notary_newsletter_deliveries_total",
           "legendFormat": "{{outcome}}",
           "refId": "A"
         }
       ],
-      "title": "Newsletter deliveries (24h)",
+      "title": "Newsletter deliveries total",
       "type": "timeseries"
     },
     {
@@ -299,12 +299,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "increase(notary_newsletter_recipients_total[24h])",
+          "expr": "notary_newsletter_recipients_total",
           "legendFormat": "{{audience_type}}",
           "refId": "A"
         }
       ],
-      "title": "Newsletter recipients (24h)",
+      "title": "Newsletter recipients total",
       "type": "timeseries"
     }
   ],

--- a/monitoring/grafana/provisioning/dashboards/business-metrics.json
+++ b/monitoring/grafana/provisioning/dashboards/business-metrics.json
@@ -246,6 +246,66 @@
       ],
       "title": "Promo discount amount (24h)",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "id": 13,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(notary_newsletter_campaigns_total[24h])",
+          "legendFormat": "{{audience_type}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Newsletter campaigns (24h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "id": 14,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(notary_newsletter_deliveries_total[24h])",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Newsletter deliveries (24h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
+      "id": 15,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(notary_newsletter_recipients_total[24h])",
+          "legendFormat": "{{audience_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Newsletter recipients (24h)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -258,6 +318,6 @@
   "timezone": "",
   "title": "Business metrics",
   "uid": "notarius-business",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }


### PR DESCRIPTION
Заменяет PR #170: сохраняет работу по метрикам рассылок и добавляет панели Grafana для собранных Prometheus-счетчиков.

Что изменено:
- добавлены панели рассылок в дашборд Business metrics;
- добавлены запросы к notary_newsletter_campaigns_total, notary_newsletter_deliveries_total и notary_newsletter_recipients_total;
- панели показывают текущие значения counters, поэтому первая же отправленная рассылка видна после scrape Prometheus;
- обновлена версия дашборда Grafana, чтобы provisioning подхватил изменение.

Проверка:
- JSON.parse для monitoring/grafana/provisioning/dashboards/business-metrics.json;
- git diff --check;
- локально подняты API, Prometheus и Grafana;
- проверено, что /metrics отдает notary_newsletter_* samples;
- проверено, что Prometheus target api находится в состоянии up;
- проверено, что Grafana загрузила newsletter-панели в Business metrics.