### PR TITLE
добавлен аудит и логирование повторной отправки

### DIFF
--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
@@ -8,6 +8,7 @@ import {
   NewsletterCampaignStatus,
   NewsletterSubscriberStatus,
   NotificationType as RpcNotificationType,
+  RepeatNewsletterCampaignRequestSchema,
   SendNewsletterCampaignRequestSchema,
   UserRole,
 } from '@notary-portal/api-contracts';
@@ -28,6 +29,7 @@ describe('NewsletterService', () => {
   const repository = {
     listSubscribers: jest.fn(),
     listCampaigns: jest.fn(),
+    getCampaignForRepeat: jest.fn(),
     resolveAudience: jest.fn(),
     createCampaign: jest.fn(),
     markDeliverySent: jest.fn(),
@@ -88,6 +90,11 @@ describe('NewsletterService', () => {
     );
     repository.listSubscribers.mockResolvedValue({ subscribers: [], meta: undefined });
     repository.listCampaigns.mockResolvedValue({ campaigns: [], meta: undefined });
+    repository.getCampaignForRepeat.mockResolvedValue({
+      subject: 'Тестовая рассылка',
+      bodyHtml: '<p>Текст письма</p>',
+      recipients: [recipient('a@example.com'), recipient('b@example.com')],
+    });
     repository.createCampaign.mockResolvedValue(
       create(NewsletterCampaignSchema, {
         id: '11111111-1111-4111-a111-111111111111',
@@ -325,6 +332,65 @@ describe('NewsletterService', () => {
     });
   });
 
+  it('records audit, notification and logs when repeating a campaign', async () => {
+    const response = await runAs(adminUser(), () =>
+      service.repeatNewsletterCampaign(validRepeatRequest()),
+    );
+
+    expect(repository.getCampaignForRepeat).toHaveBeenCalledWith(
+      '22222222-2222-4222-a222-222222222222',
+    );
+    expect(mailer.sendNewsletterEmail).toHaveBeenCalledTimes(2);
+    expect(repository.markDeliverySent).toHaveBeenCalledTimes(2);
+    expect(repository.completeCampaign).toHaveBeenCalledWith(
+      '11111111-1111-4111-a111-111111111111',
+      {
+        sentCount: 2,
+        failedCount: 0,
+        status: PrismaNewsletterCampaignStatus.Sent,
+      },
+    );
+    expect(auditService.record).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        eventType: 'newsletter.campaign.repeat_started',
+        targetType: 'NewsletterCampaign',
+        after: expect.objectContaining({
+          sourceCampaignId: '22222222-2222-4222-a222-222222222222',
+          status: 'sending',
+        }),
+      }),
+    );
+    expect(auditService.record).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        eventType: 'newsletter.campaign.repeat_completed',
+        targetType: 'NewsletterCampaign',
+        after: expect.objectContaining({
+          sourceCampaignId: '22222222-2222-4222-a222-222222222222',
+          sentCount: 2,
+          failedCount: 0,
+          status: 'sent',
+        }),
+      }),
+    );
+    expect(notificationService.createNotification).toHaveBeenCalledWith({
+      userId: '11111111-1111-4111-a111-111111111111',
+      type: RpcNotificationType.PUSH,
+      message:
+        'Рассылка «Тестовая рассылка» завершена: отправлено 2 из 2, ошибок 0.',
+    });
+    expect(logger.log).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('newsletter.campaign.started'),
+    );
+    expect(logger.log).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('newsletter.campaign.completed'),
+    );
+    expect(response.campaign?.sentCount).toBe(2);
+  });
+
   it('rejects empty audience and invalid body before sending', async () => {
     repository.resolveAudience.mockResolvedValue([]);
 
@@ -389,6 +455,12 @@ function validSendRequest() {
     audience: { type: NewsletterAudienceType.ALL },
     subject: 'Тестовая рассылка',
     bodyHtml: '<p>Текст письма</p>',
+  });
+}
+
+function validRepeatRequest() {
+  return create(RepeatNewsletterCampaignRequestSchema, {
+    id: '22222222-2222-4222-a222-222222222222',
   });
 }
 

--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
@@ -264,6 +264,17 @@ export class NewsletterService {
       recipients: source.recipients,
     });
 
+    this.logCampaignStart(campaign.id, source.subject, campaign.audienceLabel, source.recipients.length);
+    await this.recordCampaignAuditBestEffort({
+      actor,
+      campaign,
+      eventType: 'newsletter.campaign.repeat_started',
+      sentCount: 0,
+      failedCount: 0,
+      status: PrismaNewsletterCampaignStatus.Sending,
+      sourceCampaignId: id,
+    });
+
     let sentCount = 0;
     let failedCount = 0;
     let interruptedError: unknown = null;
@@ -278,11 +289,13 @@ export class NewsletterService {
             bodyHtml: source.bodyHtml,
           });
         } catch (error) {
+          const deliveryErrorMessage = normalizeErrorMessage(error);
           failedCount += 1;
+          this.logDeliveryFailure(campaign.id, recipient.email, deliveryErrorMessage);
           await this.newsletterRepository.markDeliveryFailed(
             campaign.id,
             recipient.email,
-            normalizeErrorMessage(error),
+            deliveryErrorMessage,
           );
           continue;
         }
@@ -294,10 +307,36 @@ export class NewsletterService {
       interruptedError = error;
     }
 
+    const finalStatus = resolveCampaignStatus(sentCount, failedCount, interruptedError !== null);
+
+    if (interruptedError) {
+      this.logger.error(
+        `newsletter.campaign.repeat_flow_interrupted campaignId=${campaign.id} sourceCampaignId=${id} status=${formatCampaignStatus(finalStatus)} sentCount=${sentCount} failedCount=${failedCount} error="${normalizeErrorMessage(interruptedError)}"`,
+      );
+    }
+
     const completedCampaign = await this.newsletterRepository.completeCampaign(campaign.id, {
       sentCount,
       failedCount,
-      status: resolveCampaignStatus(sentCount, failedCount, interruptedError !== null),
+      status: finalStatus,
+    });
+
+    this.logCampaignCompletion(campaign.id, finalStatus, sentCount, failedCount);
+    await this.recordCampaignAuditBestEffort({
+      actor,
+      campaign: completedCampaign,
+      eventType: 'newsletter.campaign.repeat_completed',
+      sentCount,
+      failedCount,
+      status: finalStatus,
+      sourceCampaignId: id,
+    });
+    await this.createCampaignSummaryNotificationBestEffort({
+      actor,
+      campaign: completedCampaign,
+      sentCount,
+      failedCount,
+      status: finalStatus,
     });
 
     return create(RepeatNewsletterCampaignResponseSchema, {
@@ -357,10 +396,15 @@ export class NewsletterService {
   private async recordCampaignAuditBestEffort(input: {
     actor: AccessTokenPayload;
     campaign: NewsletterCampaignSummary;
-    eventType: 'newsletter.campaign.started' | 'newsletter.campaign.completed';
+    eventType:
+      | 'newsletter.campaign.started'
+      | 'newsletter.campaign.completed'
+      | 'newsletter.campaign.repeat_started'
+      | 'newsletter.campaign.repeat_completed';
     sentCount: number;
     failedCount: number;
     status: PrismaNewsletterCampaignStatus;
+    sourceCampaignId?: string;
   }): Promise<void> {
     try {
       await this.auditService.record({
@@ -368,14 +412,8 @@ export class NewsletterService {
         eventType: input.eventType,
         targetType: 'NewsletterCampaign',
         targetId: input.campaign.id,
-        actionTitle:
-          input.eventType === 'newsletter.campaign.started'
-            ? 'Запущена кампания рассылки'
-            : 'Кампания рассылки завершена',
-        actionContext:
-          input.eventType === 'newsletter.campaign.started'
-            ? `Получателей: ${input.campaign.recipientsCount}`
-            : `Отправлено: ${input.sentCount}, ошибок: ${input.failedCount}`,
+        actionTitle: newsletterAuditTitle(input.eventType),
+        actionContext: newsletterAuditContext(input),
         targetTitle: input.campaign.subject,
         targetContext: input.campaign.audienceLabel,
         after: {
@@ -385,6 +423,7 @@ export class NewsletterService {
           sentCount: input.sentCount,
           failedCount: input.failedCount,
           status: formatCampaignStatus(input.status),
+          ...(input.sourceCampaignId && { sourceCampaignId: input.sourceCampaignId }),
           actor: {
             userId: input.actor.sub,
             email: input.actor.email,
@@ -575,6 +614,39 @@ function buildCampaignSummaryNotificationMessage(
   }
 
   return `Рассылка «${subject}» завершена с ошибками: отправлено ${sentCount} из ${recipientsCount}, ошибок ${failedCount}.`;
+}
+
+function newsletterAuditTitle(
+  eventType:
+    | 'newsletter.campaign.started'
+    | 'newsletter.campaign.completed'
+    | 'newsletter.campaign.repeat_started'
+    | 'newsletter.campaign.repeat_completed',
+): string {
+  if (eventType === 'newsletter.campaign.started') return 'Запущена кампания рассылки';
+  if (eventType === 'newsletter.campaign.repeat_started') return 'Запущена повторная рассылка';
+  if (eventType === 'newsletter.campaign.repeat_completed') return 'Повторная рассылка завершена';
+  return 'Кампания рассылки завершена';
+}
+
+function newsletterAuditContext(input: {
+  eventType:
+    | 'newsletter.campaign.started'
+    | 'newsletter.campaign.completed'
+    | 'newsletter.campaign.repeat_started'
+    | 'newsletter.campaign.repeat_completed';
+  campaign: NewsletterCampaignSummary;
+  sentCount: number;
+  failedCount: number;
+  sourceCampaignId?: string;
+}): string {
+  if (input.eventType === 'newsletter.campaign.started') {
+    return `Получателей: ${input.campaign.recipientsCount}`;
+  }
+  if (input.eventType === 'newsletter.campaign.repeat_started') {
+    return `Повторная отправка по кампании ${input.sourceCampaignId ?? '—'}, получателей: ${input.campaign.recipientsCount}`;
+  }
+  return `Отправлено: ${input.sentCount}, ошибок: ${input.failedCount}`;
 }
 
 function escapeHtml(value: string): string {


### PR DESCRIPTION
- Добавлен аудит для повторной отправки рассылки
- Добавлены события newsletter.campaign.repeat_started и newsletter.campaign.repeat_completed
- В audit сохраняется sourceCampaignId исходной рассылки
- Добавлено логирование старта, ошибок доставки и завершения повторной отправки
- Добавлено уведомление о результате повторной отправки
- Добавлен тест на audit, notification и logs для повторной отправки