### PR TITLE
добавлен аудит повторной рассылки

### DIFF
--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
@@ -8,14 +8,11 @@ import {
   NewsletterCampaignStatus,
   NewsletterSubscriberStatus,
   NotificationType as RpcNotificationType,
+  RepeatNewsletterCampaignRequestSchema,
   SendNewsletterCampaignRequestSchema,
   UserRole,
 } from '@notary-portal/api-contracts';
-import {
-  Role,
-  requestContextStorage,
-  type AccessTokenPayload,
-} from '@internal/auth-shared';
+import { Role, requestContextStorage, type AccessTokenPayload } from '@internal/auth-shared';
 import {
   NewsletterAudienceType as PrismaNewsletterAudienceType,
   NewsletterCampaignStatus as PrismaNewsletterCampaignStatus,
@@ -28,6 +25,7 @@ describe('NewsletterService', () => {
   const repository = {
     listSubscribers: jest.fn(),
     listCampaigns: jest.fn(),
+    getCampaignForRepeat: jest.fn(),
     resolveAudience: jest.fn(),
     createCampaign: jest.fn(),
     markDeliverySent: jest.fn(),
@@ -94,6 +92,7 @@ describe('NewsletterService', () => {
     );
     repository.listSubscribers.mockResolvedValue({ subscribers: [], meta: undefined });
     repository.listCampaigns.mockResolvedValue({ campaigns: [], meta: undefined });
+    repository.getCampaignForRepeat.mockResolvedValue(null);
     repository.createCampaign.mockResolvedValue(
       create(NewsletterCampaignSchema, {
         id: '11111111-1111-4111-a111-111111111111',
@@ -153,14 +152,12 @@ describe('NewsletterService', () => {
 
   it('rejects non-admin access', async () => {
     expect(() =>
-      runAs(
-        { ...adminUser(), role: Role.Notary },
-        () =>
-          service.listNewsletterSubscribers(
-            create(ListNewsletterSubscribersRequestSchema, {
-              pagination: { page: 1, limit: 20 },
-            }),
-          ),
+      runAs({ ...adminUser(), role: Role.Notary }, () =>
+        service.listNewsletterSubscribers(
+          create(ListNewsletterSubscribersRequestSchema, {
+            pagination: { page: 1, limit: 20 },
+          }),
+        ),
       ),
     ).toThrow(ConnectError);
   });
@@ -250,8 +247,7 @@ describe('NewsletterService', () => {
     expect(notificationService.createNotification).toHaveBeenCalledWith({
       userId: '11111111-1111-4111-a111-111111111111',
       type: RpcNotificationType.PUSH,
-      message:
-        'Рассылка «Тестовая рассылка» завершена: отправлено 2 из 2, ошибок 0.',
+      message: 'Рассылка «Тестовая рассылка» завершена: отправлено 2 из 2, ошибок 0.',
     });
     expect(logger.log).toHaveBeenNthCalledWith(
       1,
@@ -271,14 +267,123 @@ describe('NewsletterService', () => {
     expect(response.campaign?.sentCount).toBe(2);
   });
 
+  it('records audit, notification and logs when repeating a campaign', async () => {
+    repository.getCampaignForRepeat.mockResolvedValue({
+      subject: 'Повторяемая рассылка',
+      bodyHtml: '<p>Еще раз</p>',
+      recipients: [recipient('a@example.com'), recipient('b@example.com')],
+    });
+    repository.createCampaign.mockResolvedValue(
+      create(NewsletterCampaignSchema, {
+        id: '22222222-2222-4222-a222-222222222222',
+        subject: 'Повторяемая рассылка',
+        audienceType: NewsletterAudienceType.SELECTED,
+        audienceLabel: 'Повторная отправка (2)',
+        recipientsCount: 2,
+        sentCount: 0,
+        failedCount: 0,
+        status: NewsletterCampaignStatus.SENDING,
+      }),
+    );
+    repository.completeCampaign.mockImplementation((_id, input) =>
+      create(NewsletterCampaignSchema, {
+        id: '22222222-2222-4222-a222-222222222222',
+        subject: 'Повторяемая рассылка',
+        audienceType: NewsletterAudienceType.SELECTED,
+        audienceLabel: 'Повторная отправка (2)',
+        recipientsCount: input.sentCount + input.failedCount,
+        sentCount: input.sentCount,
+        failedCount: input.failedCount,
+        status: toRpcCampaignStatus(input.status),
+      }),
+    );
+
+    const response = await runAs(adminUser(), () =>
+      service.repeatNewsletterCampaign(validRepeatRequest()),
+    );
+
+    expect(repository.getCampaignForRepeat).toHaveBeenCalledWith(
+      '33333333-3333-4333-a333-333333333333',
+    );
+    expect(mailer.sendNewsletterEmail).toHaveBeenCalledTimes(2);
+    expect(mailer.sendNewsletterEmail).toHaveBeenNthCalledWith(1, {
+      to: 'a@example.com',
+      fullName: 'Тестовый пользователь',
+      subject: 'Повторяемая рассылка',
+      bodyHtml: '<p>Еще раз</p>',
+    });
+    expect(repository.markDeliverySent).toHaveBeenCalledTimes(2);
+    expect(repository.markDeliverySent).toHaveBeenNthCalledWith(
+      1,
+      '22222222-2222-4222-a222-222222222222',
+      'a@example.com',
+    );
+    expect(repository.markDeliverySent).toHaveBeenNthCalledWith(
+      2,
+      '22222222-2222-4222-a222-222222222222',
+      'b@example.com',
+    );
+    expect(repository.completeCampaign).toHaveBeenCalledWith(
+      '22222222-2222-4222-a222-222222222222',
+      {
+        sentCount: 2,
+        failedCount: 0,
+        status: PrismaNewsletterCampaignStatus.Sent,
+      },
+    );
+    expect(auditService.record).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        eventType: 'newsletter.campaign.repeat_started',
+        targetType: 'NewsletterCampaign',
+        targetId: '22222222-2222-4222-a222-222222222222',
+        after: expect.objectContaining({
+          sourceCampaignId: '33333333-3333-4333-a333-333333333333',
+          subject: 'Повторяемая рассылка',
+          sentCount: 0,
+          failedCount: 0,
+          status: 'sending',
+        }),
+      }),
+    );
+    expect(auditService.record).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        eventType: 'newsletter.campaign.repeat_completed',
+        targetType: 'NewsletterCampaign',
+        targetId: '22222222-2222-4222-a222-222222222222',
+        after: expect.objectContaining({
+          sourceCampaignId: '33333333-3333-4333-a333-333333333333',
+          sentCount: 2,
+          failedCount: 0,
+          status: 'sent',
+        }),
+      }),
+    );
+    expect(notificationService.createNotification).toHaveBeenCalledWith({
+      userId: '11111111-1111-4111-a111-111111111111',
+      type: RpcNotificationType.PUSH,
+      message: 'Рассылка «Повторяемая рассылка» завершена: отправлено 2 из 2, ошибок 0.',
+    });
+    expect(logger.log).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('newsletter.campaign.repeat_started'),
+    );
+    expect(logger.log).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('newsletter.campaign.repeat_completed'),
+    );
+    expect(response.campaign?.sentCount).toBe(2);
+  });
+
   it('records a partial failure when one delivery fails', async () => {
     repository.resolveAudience.mockResolvedValue([
       recipient('a@example.com'),
       recipient('b@example.com'),
     ]);
-    mailer.sendNewsletterEmail.mockResolvedValueOnce(undefined).mockRejectedValueOnce(
-      new Error('SMTP rejected recipient'),
-    );
+    mailer.sendNewsletterEmail
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('SMTP rejected recipient'));
 
     await runAs(adminUser(), () => service.sendNewsletterCampaign(validSendRequest()));
 
@@ -303,20 +408,20 @@ describe('NewsletterService', () => {
       expect.stringContaining('newsletter.campaign.delivery_failed'),
     );
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('b@example.com'));
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('SMTP rejected recipient'),
-    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('SMTP rejected recipient'));
     expect(notificationService.createNotification).toHaveBeenCalledWith({
       userId: '11111111-1111-4111-a111-111111111111',
       type: RpcNotificationType.PUSH,
-      message:
-        'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 1 из 2, ошибок 1.',
+      message: 'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 1 из 2, ошибок 1.',
     });
     expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('all', 2);
     expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(2);
     expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(1, 'sent');
     expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(2, 'failed');
-    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith('all', 'partial_failed');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith(
+      'all',
+      'partial_failed',
+    );
   });
 
   it('marks campaign as failed when all deliveries fail', async () => {
@@ -339,8 +444,7 @@ describe('NewsletterService', () => {
     expect(notificationService.createNotification).toHaveBeenCalledWith({
       userId: '11111111-1111-4111-a111-111111111111',
       type: RpcNotificationType.PUSH,
-      message:
-        'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 0 из 1, ошибок 1.',
+      message: 'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 0 из 1, ошибок 1.',
     });
     expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('all', 1);
     expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(1);
@@ -351,7 +455,9 @@ describe('NewsletterService', () => {
   it('rejects empty audience and invalid body before sending', async () => {
     repository.resolveAudience.mockResolvedValue([]);
 
-    await expect(runAs(adminUser(), () => service.sendNewsletterCampaign(validSendRequest()))).rejects.toMatchObject({
+    await expect(
+      runAs(adminUser(), () => service.sendNewsletterCampaign(validSendRequest())),
+    ).rejects.toMatchObject({
       code: Code.FailedPrecondition,
     });
     await expect(
@@ -404,14 +510,16 @@ describe('NewsletterService', () => {
     expect(notificationService.createNotification).toHaveBeenCalledWith({
       userId: '11111111-1111-4111-a111-111111111111',
       type: RpcNotificationType.PUSH,
-      message:
-        'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 2 из 2, ошибок 0.',
+      message: 'Рассылка «Тестовая рассылка» завершена с ошибками: отправлено 2 из 2, ошибок 0.',
     });
     expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('all', 2);
     expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(2);
     expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(1, 'sent');
     expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(2, 'sent');
-    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith('all', 'partial_failed');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith(
+      'all',
+      'partial_failed',
+    );
   });
 });
 
@@ -420,6 +528,12 @@ function validSendRequest() {
     audience: { type: NewsletterAudienceType.ALL },
     subject: 'Тестовая рассылка',
     bodyHtml: '<p>Текст письма</p>',
+  });
+}
+
+function validRepeatRequest() {
+  return create(RepeatNewsletterCampaignRequestSchema, {
+    id: '33333333-3333-4333-a333-333333333333',
   });
 }
 

--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
@@ -3,7 +3,11 @@ import { Code, ConnectError } from '@connectrpc/connect';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { AuditService } from '@internal/audit';
 import { Role, requireRole, type AccessTokenPayload } from '@internal/auth-shared';
-import { MetricsService, type NewsletterAudienceMetricType, type NewsletterCampaignMetricStatus } from '@internal/metrics';
+import {
+  MetricsService,
+  type NewsletterAudienceMetricType,
+  type NewsletterCampaignMetricStatus,
+} from '@internal/metrics';
 import { NotificationService } from '@internal/notification';
 import {
   EstimateNewsletterAudienceResponseSchema,
@@ -32,14 +36,8 @@ import {
   NewsletterCampaignStatus as PrismaNewsletterCampaignStatus,
   Role as PrismaRole,
 } from '@internal/prisma-client';
-import {
-  NEWSLETTER_MAILER,
-  type NewsletterMailer,
-} from './newsletter-mailer.interface';
-import {
-  NewsletterRepository,
-  type NewsletterAudienceQuery,
-} from './newsletter.repository';
+import { NEWSLETTER_MAILER, type NewsletterMailer } from './newsletter-mailer.interface';
+import { NewsletterRepository, type NewsletterAudienceQuery } from './newsletter.repository';
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 20;
@@ -54,6 +52,12 @@ interface NewsletterCampaignSummary {
   audienceLabel: string;
   recipientsCount: number;
 }
+
+type NewsletterCampaignAuditEventType =
+  | 'newsletter.campaign.started'
+  | 'newsletter.campaign.completed'
+  | 'newsletter.campaign.repeat_started'
+  | 'newsletter.campaign.repeat_completed';
 
 @Injectable()
 export class NewsletterService {
@@ -274,6 +278,23 @@ export class NewsletterService {
       recipients: source.recipients,
     });
 
+    this.logCampaignStart(
+      campaign.id,
+      source.subject,
+      campaign.audienceLabel,
+      source.recipients.length,
+      'newsletter.campaign.repeat_started',
+    );
+    await this.recordCampaignAuditBestEffort({
+      actor,
+      campaign,
+      eventType: 'newsletter.campaign.repeat_started',
+      sourceCampaignId: id,
+      sentCount: 0,
+      failedCount: 0,
+      status: PrismaNewsletterCampaignStatus.Sending,
+    });
+
     let sentCount = 0;
     let failedCount = 0;
     let interruptedError: unknown = null;
@@ -288,26 +309,73 @@ export class NewsletterService {
             bodyHtml: source.bodyHtml,
           });
         } catch (error) {
+          const deliveryErrorMessage = normalizeErrorMessage(error);
           failedCount += 1;
-          await this.newsletterRepository.markDeliveryFailed(
-            campaign.id,
-            recipient.email,
-            normalizeErrorMessage(error),
-          );
+          this.logDeliveryFailure(campaign.id, recipient.email, deliveryErrorMessage);
+
+          try {
+            await this.newsletterRepository.markDeliveryFailed(
+              campaign.id,
+              recipient.email,
+              deliveryErrorMessage,
+            );
+          } catch (deliveryUpdateError) {
+            interruptedError = deliveryUpdateError;
+            break;
+          }
+
           continue;
         }
 
         sentCount += 1;
-        await this.newsletterRepository.markDeliverySent(campaign.id, recipient.email);
+
+        try {
+          await this.newsletterRepository.markDeliverySent(campaign.id, recipient.email);
+        } catch (deliveryUpdateError) {
+          interruptedError = deliveryUpdateError;
+          break;
+        }
       }
     } catch (error) {
       interruptedError = error;
     }
 
+    const finalStatus = resolveCampaignStatus(sentCount, failedCount, interruptedError !== null);
+
+    if (interruptedError) {
+      this.logger.error(
+        `newsletter.campaign.repeat_flow_interrupted campaignId=${campaign.id} sourceCampaignId=${id} status=${formatCampaignStatus(finalStatus)} sentCount=${sentCount} failedCount=${failedCount} error="${normalizeErrorMessage(interruptedError)}"`,
+      );
+    }
+
     const completedCampaign = await this.newsletterRepository.completeCampaign(campaign.id, {
       sentCount,
       failedCount,
-      status: resolveCampaignStatus(sentCount, failedCount, interruptedError !== null),
+      status: finalStatus,
+    });
+
+    this.logCampaignCompletion(
+      campaign.id,
+      finalStatus,
+      sentCount,
+      failedCount,
+      'newsletter.campaign.repeat_completed',
+    );
+    await this.recordCampaignAuditBestEffort({
+      actor,
+      campaign: completedCampaign,
+      eventType: 'newsletter.campaign.repeat_completed',
+      sourceCampaignId: id,
+      sentCount,
+      failedCount,
+      status: finalStatus,
+    });
+    await this.createCampaignSummaryNotificationBestEffort({
+      actor,
+      campaign: completedCampaign,
+      sentCount,
+      failedCount,
+      status: finalStatus,
     });
 
     return create(RepeatNewsletterCampaignResponseSchema, {
@@ -320,10 +388,13 @@ export class NewsletterService {
     subject: string,
     audienceLabel: string,
     recipientsCount: number,
+    event:
+      | 'newsletter.campaign.started'
+      | 'newsletter.campaign.repeat_started' = 'newsletter.campaign.started',
   ): void {
     this.logger.log(
       JSON.stringify({
-        event: 'newsletter.campaign.started',
+        event,
         campaignId,
         subject,
         audienceLabel,
@@ -352,10 +423,13 @@ export class NewsletterService {
     status: PrismaNewsletterCampaignStatus,
     sentCount: number,
     failedCount: number,
+    event:
+      | 'newsletter.campaign.completed'
+      | 'newsletter.campaign.repeat_completed' = 'newsletter.campaign.completed',
   ): void {
     this.logger.log(
       JSON.stringify({
-        event: 'newsletter.campaign.completed',
+        event,
         campaignId,
         status: formatCampaignStatus(status),
         sentCount,
@@ -367,7 +441,8 @@ export class NewsletterService {
   private async recordCampaignAuditBestEffort(input: {
     actor: AccessTokenPayload;
     campaign: NewsletterCampaignSummary;
-    eventType: 'newsletter.campaign.started' | 'newsletter.campaign.completed';
+    eventType: NewsletterCampaignAuditEventType;
+    sourceCampaignId?: string;
     sentCount: number;
     failedCount: number;
     status: PrismaNewsletterCampaignStatus;
@@ -378,17 +453,17 @@ export class NewsletterService {
         eventType: input.eventType,
         targetType: 'NewsletterCampaign',
         targetId: input.campaign.id,
-        actionTitle:
-          input.eventType === 'newsletter.campaign.started'
-            ? 'Запущена кампания рассылки'
-            : 'Кампания рассылки завершена',
-        actionContext:
-          input.eventType === 'newsletter.campaign.started'
-            ? `Получателей: ${input.campaign.recipientsCount}`
-            : `Отправлено: ${input.sentCount}, ошибок: ${input.failedCount}`,
+        actionTitle: newsletterAuditTitle(input.eventType),
+        actionContext: newsletterAuditContext(
+          input.eventType,
+          input.campaign.recipientsCount,
+          input.sentCount,
+          input.failedCount,
+        ),
         targetTitle: input.campaign.subject,
         targetContext: input.campaign.audienceLabel,
         after: {
+          ...(input.sourceCampaignId ? { sourceCampaignId: input.sourceCampaignId } : {}),
           subject: input.campaign.subject,
           audienceLabel: input.campaign.audienceLabel,
           recipientsCount: input.campaign.recipientsCount,
@@ -465,7 +540,10 @@ export class NewsletterService {
 
       const invalid = selectedUserIds.find((id) => !isUuid(id));
       if (invalid) {
-        throw new ConnectError('audience.selected_user_ids must contain UUID values', Code.InvalidArgument);
+        throw new ConnectError(
+          'audience.selected_user_ids must contain UUID values',
+          Code.InvalidArgument,
+        );
       }
 
       return { type, selectedUserIds };
@@ -478,7 +556,10 @@ export class NewsletterService {
 function normalizePageLimit(value: number | undefined): number {
   const limit = normalizePositiveInt(value, DEFAULT_LIMIT);
   if (limit > MAX_PAGE_LIMIT) {
-    throw new ConnectError(`pagination.limit must not exceed ${MAX_PAGE_LIMIT}`, Code.InvalidArgument);
+    throw new ConnectError(
+      `pagination.limit must not exceed ${MAX_PAGE_LIMIT}`,
+      Code.InvalidArgument,
+    );
   }
   return limit;
 }
@@ -502,7 +583,10 @@ function normalizeRequiredString(value: string, field: string, maxLength: number
     throw new ConnectError(`${field} is required`, Code.InvalidArgument);
   }
   if (normalized.length > maxLength) {
-    throw new ConnectError(`${field} must not exceed ${maxLength} characters`, Code.InvalidArgument);
+    throw new ConnectError(
+      `${field} must not exceed ${maxLength} characters`,
+      Code.InvalidArgument,
+    );
   }
   return normalized;
 }
@@ -538,6 +622,35 @@ function roleLabel(role: NewsletterAudienceQuery['role']): string {
   if (role === PrismaRole.Admin) return 'Администратор';
   if (role === PrismaRole.Notary) return 'Нотариус';
   return 'Заявитель';
+}
+
+function newsletterAuditTitle(eventType: NewsletterCampaignAuditEventType): string {
+  if (eventType === 'newsletter.campaign.started') {
+    return 'Запущена кампания рассылки';
+  }
+  if (eventType === 'newsletter.campaign.completed') {
+    return 'Кампания рассылки завершена';
+  }
+  if (eventType === 'newsletter.campaign.repeat_started') {
+    return 'Запущена повторная отправка рассылки';
+  }
+  return 'Повторная отправка рассылки завершена';
+}
+
+function newsletterAuditContext(
+  eventType: NewsletterCampaignAuditEventType,
+  recipientsCount: number,
+  sentCount: number,
+  failedCount: number,
+): string {
+  if (
+    eventType === 'newsletter.campaign.started' ||
+    eventType === 'newsletter.campaign.repeat_started'
+  ) {
+    return `Получателей: ${recipientsCount}`;
+  }
+
+  return `Отправлено: ${sentCount}, ошибок: ${failedCount}`;
 }
 
 function toMetricAudienceType(type: PrismaNewsletterAudienceType): NewsletterAudienceMetricType {


### PR DESCRIPTION
- Добавлен аудит для повторной отправки рассылки
- Добавлены события newsletter.campaign.repeat_started и newsletter.campaign.repeat_completed
- В audit after сохраняется sourceCampaignId исходной рассылки
- Добавлено логирование старта, ошибок доставки, прерывания flow и завершения повторной отправки
- Добавлено уведомление о результате повторной отправки
- Расширен recordCampaignAuditBestEffort для обычных и repeat-событий
- Вынесены newsletterAuditTitle и newsletterAuditContext
- Добавлен тест на audit, notification и logs для повторной отправки