### PR TITLE
Добавлены метрики и тесты для повторной отправки рассылок

### DIFF
--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
@@ -373,6 +373,14 @@ describe('NewsletterService', () => {
       2,
       expect.stringContaining('newsletter.campaign.repeat_completed'),
     );
+    expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('selected', 2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(1, 'sent');
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(2, 'sent');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith(
+      'selected',
+      'sent',
+    );
     expect(response.campaign?.sentCount).toBe(2);
   });
 

--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
@@ -264,6 +264,7 @@ export class NewsletterService {
       throw new ConnectError('newsletter campaign has no recipients', Code.FailedPrecondition);
     }
 
+    const audienceMetricType: NewsletterAudienceMetricType = 'selected';
     const campaign = await this.newsletterRepository.createCampaign({
       createdById: isUuid(actor.sub) ? actor.sub : null,
       subject: source.subject,
@@ -284,6 +285,10 @@ export class NewsletterService {
       campaign.audienceLabel,
       source.recipients.length,
       'newsletter.campaign.repeat_started',
+    );
+    this.metricsService.recordNewsletterCampaignStarted(
+      audienceMetricType,
+      source.recipients.length,
     );
     await this.recordCampaignAuditBestEffort({
       actor,
@@ -311,6 +316,7 @@ export class NewsletterService {
         } catch (error) {
           const deliveryErrorMessage = normalizeErrorMessage(error);
           failedCount += 1;
+          this.metricsService.recordNewsletterDelivery('failed');
           this.logDeliveryFailure(campaign.id, recipient.email, deliveryErrorMessage);
 
           try {
@@ -328,6 +334,7 @@ export class NewsletterService {
         }
 
         sentCount += 1;
+        this.metricsService.recordNewsletterDelivery('sent');
 
         try {
           await this.newsletterRepository.markDeliverySent(campaign.id, recipient.email);
@@ -360,6 +367,10 @@ export class NewsletterService {
       sentCount,
       failedCount,
       'newsletter.campaign.repeat_completed',
+    );
+    this.metricsService.recordNewsletterCampaignCompleted(
+      audienceMetricType,
+      formatCampaignStatus(finalStatus) as NewsletterCampaignMetricStatus,
     );
     await this.recordCampaignAuditBestEffort({
       actor,


### PR DESCRIPTION
Добавлены вызовы metricsService в функцию repeatNewsletterCampaign:
- recordNewsletterCampaignStarted при старте кампании
- recordNewsletterDelivery для каждого письма ('sent' или 'failed')
- recordNewsletterCampaignCompleted при завершении

Расширены unit тесты в newsletter.service.spec.ts:
- Проверка вызова метрик при успешной повторной отправке
- Проверка правильных параметров (audienceType='selected')
- Проверка финального статуса кампании