### PR TITLE
Добавлены метрики и тесты для повторной отправки рассылки

### DIFF
--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.spec.ts
@@ -379,6 +379,11 @@ describe('NewsletterService', () => {
       2,
       expect.stringContaining('newsletter.campaign.repeat_completed'),
     );
+    expect(metricsService.recordNewsletterCampaignStarted).toHaveBeenCalledWith('selected', 2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenCalledTimes(2);
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(1, 'sent');
+    expect(metricsService.recordNewsletterDelivery).toHaveBeenNthCalledWith(2, 'sent');
+    expect(metricsService.recordNewsletterCampaignCompleted).toHaveBeenCalledWith('selected', 'sent');
     expect(response.campaign?.sentCount).toBe(2);
   });
 

--- a/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
+++ b/libs/api/newsletter/src/lib/newsletter/newsletter.service.ts
@@ -398,6 +398,7 @@ export class NewsletterService {
         );
 
         this.logCampaignStart(source.recipients.length, 'newsletter.campaign.repeat_started');
+        this.metricsService.recordNewsletterCampaignStarted('selected', source.recipients.length);
         await this.recordCampaignAuditBestEffort({
           actor,
           campaign,
@@ -433,6 +434,7 @@ export class NewsletterService {
                 } catch (error) {
                   const deliveryErrorMessage = normalizeErrorMessage(error);
                   failedCount += 1;
+                  this.metricsService.recordNewsletterDelivery('failed');
                   this.logDeliveryFailure(error);
 
                   try {
@@ -450,6 +452,7 @@ export class NewsletterService {
                 }
 
                 sentCount += 1;
+                this.metricsService.recordNewsletterDelivery('sent');
 
                 try {
                   await this.newsletterRepository.markDeliverySent(campaign.id, recipient.email);
@@ -508,6 +511,10 @@ export class NewsletterService {
           delivery.sentCount,
           delivery.failedCount,
           'newsletter.campaign.repeat_completed',
+        );
+        this.metricsService.recordNewsletterCampaignCompleted(
+          'selected',
+          formatCampaignStatus(finalStatus) as NewsletterCampaignMetricStatus,
         );
         await this.recordCampaignAuditBestEffort({
           actor,


### PR DESCRIPTION
Добавлены вызовы metricsService в функцию repeatNewsletterCampaign:

• recordNewsletterCampaignStarted при старте кампании
• recordNewsletterDelivery для каждого письма ('sent' или 'failed')
• recordNewsletterCampaignCompleted при завершении

Расширены unit тесты в newsletter.service.spec.ts:

• Проверка вызова метрик при успешной повторной отправке
• Проверка правильных параметров (audienceType='selected')
• Проверка финального статуса кампании

Запуск тестов:
pnpm nx test newsletter 
pnpm nx test admin --testFile=newsletter